### PR TITLE
Add GET /resources endpoint

### DIFF
--- a/db_setup/app/__init__.py
+++ b/db_setup/app/__init__.py
@@ -4,6 +4,9 @@ from flask import Flask
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import exc
+from flask import jsonify
+import json
+import traceback
 
 from configs import Config
 
@@ -15,6 +18,19 @@ migrate = Migrate(app, db)
 
 from .models import Resource, Category, Language
 
+@app.route('/resources', methods=['GET'])
+def resources():
+    return get_resources()
+
+def get_resources():
+    resources = {}
+    try:
+        resources = Resource.query.all()
+    except Exception as e:
+        traceback.print_tb(e.__traceback__)
+        print(e)
+
+    return jsonify([i.serialize for i in resources])
 
 def import_resources():
     # Step 1: Get data

--- a/db_setup/app/__init__.py
+++ b/db_setup/app/__init__.py
@@ -30,7 +30,7 @@ def get_resources():
         traceback.print_tb(e.__traceback__)
         print(e)
 
-    return jsonify([i.serialize for i in resources])
+    return jsonify([single_resource.serialize for single_resource in resources])
 
 def import_resources():
     # Step 1: Get data

--- a/db_setup/app/models.py
+++ b/db_setup/app/models.py
@@ -28,6 +28,26 @@ class Resource(db.Model):
     downvotes = db.Column(db.INTEGER, default=0)
     times_clicked = db.Column(db.INTEGER, default=0)
 
+    @property
+    def serialize(self):
+       """Return object data in easily serializeable format"""
+       return {
+           'id'            : self.id,
+           'name'          : self.name,
+           'url'           : self.url,
+           'category'      : self.category.name,
+           'languages'     : self.serialize_languages,
+           'paid'          : self.paid,
+           'notes'         : self.notes,
+           'upvotes'       : self.upvotes,
+           'downvotes'     : self.downvotes,
+           'times_clicked' : self.times_clicked
+       }
+
+    @property
+    def serialize_languages(self):
+        return [ lang.name for lang in self.languages ]
+
     def key(self):
         return self.url
 


### PR DESCRIPTION
This adds a route for getting all resources.

Issues:
- I don't know whether putting the route in `__init__.py` is the right choice.
- There's no pagination so it takes a very long time to return results
- I'm not sure what the significance of `@property` is for the `serialize()` method, but that's what the example on StackOverflow used... so if that doesn't need to be a property, we can change that I'm sure