### PR TITLE
Add create_tables click command for easier setup of local db

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ export SQLALCHEMY_DATABASE_URI=postgresql://aaron:password@127.0.0.1:5432/resour
 11. Activate virtual environment `source venv/bin/activate`
 12. Install the required dependencies `pip install -r requirements.txt`
 13. Set the FLASK_APP environment variable `export FLASK_APP=run.py` or `ENV:FLASK_APP = "run.py"`
-14. Set the FLASK_APP environment variable `export FLASK_APP=run.py`
-15. Run the migration `flask db migrate`
-16. Upgrade to the latest migration `flask db upgrade`
-17. Run the click command to populate your database with the resources `flask db_migrate init`
+14. Optionally, enable debugging by setting the environment to development with `export FLASK_ENV=development`
+15. Create the tables in your database with `flask db_migrate create_tables`
+16. Tell flask that your database is up to date with `flask db stamp head`
+17. Populate your database with the resources `flask db_migrate init`
 18. Start your development server with `flask run` and you're ready to go!
-19. Optionally, enable debugging by setting the environment to development with `export FLASK_ENV=development`
 
 
 ## Development Notes

--- a/app/cli.py
+++ b/app/cli.py
@@ -38,7 +38,7 @@ def import_resources(db):
         if existing_resource:
             resource == existing_resource or update_resource(resource, existing_resource)
         else:
-            create_resource(resource)
+            create_resource(resource, db)
 
     try:
         db.session.commit()
@@ -134,3 +134,7 @@ def register(app, db):
         stop = time.perf_counter()
         print("Finished populating db from resources.yml")
         print(f"Elapsed time: {(stop-start)/60} [min]")
+
+    @db_migrate.command()
+    def create_tables():
+        db.create_all()


### PR DESCRIPTION
Turns out that `db.create_all()` was the missing line we needed to create the tables in a fresh db. It can now be ran using `flask db_migrate create_tables`.

Also, when you run `flask db_migrate init`, the db needs to be passed into the `create_resource()` function, this PR also fixes that too.