### PR TITLE
Add pagination for the get_resources route

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from app.api import bp
 from app.models import Resource, Language
 from app import Config
+from app.utils import Paginator
 
 
 # Routes
@@ -48,10 +49,7 @@ def get_resource(id):
 
 def get_resources():
     try:
-        page = request.args.get('page', 1, type=int)
-        page_size = request.args.get('page_size', Config.RESOURCES_PER_PAGE, type=int)
-        if page_size > Config.RESOURCE_MAX_PAGE_SIZE: page_size = Config.RESOURCE_MAX_PAGE_SIZE
-        resource_paginator = Resource.query.paginate(page, page_size, False)
+        resource_paginator = Paginator(Config.RESOURCE_PAGINATOR, Resource, request)
         resource_list = [resource.serialize for resource in resource_paginator.items]
 
     except Exception as e:
@@ -66,10 +64,7 @@ def get_languages():
     languages = {}
 
     try:
-        page = request.args.get('page', 1, type=int)
-        page_size = request.args.get('page_size', Config.LANGUAGES_PER_PAGE, type=int)
-        if page_size > Config.LANGUAGES_MAX_PAGE_SIZE: page_size = Config.LANGUAGES_MAX_PAGE_SIZE
-        language_paginator = Language.query.paginate(page, page_size, False)
+        language_paginator = Paginator(Config.LANGUAGE_PAGINATOR, Language, request)
         language_list = [language.serialize for language in language_paginator.items]
 
     except Exception as e:

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,10 +1,12 @@
 from traceback import print_tb
 
+from flask import request
 from flask import jsonify
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from app.api import bp
 from app.models import Resource, Language
+from app import Config
 
 
 # Routes
@@ -47,14 +49,16 @@ def get_resource(id):
 def get_resources():
     resources = {}
     try:
-        resources = Resource.query.all()
+        page = request.args.get('page', 1, type=int)
+        resource_paginator = Resource.query.paginate(page, Config.RESOURCES_PER_PAGE, False)
+        resource_list = [resource.serialize for resource in resource_paginator.items]
 
     except Exception as e:
         print_tb(e.__traceback__)
         print(e)
 
     finally:
-        return jsonify([single_resource.serialize for single_resource in resources])
+        return jsonify(resource_list)
 
 
 def get_languages():

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -49,7 +49,9 @@ def get_resource(id):
 def get_resources():
     try:
         page = request.args.get('page', 1, type=int)
-        resource_paginator = Resource.query.paginate(page, Config.RESOURCES_PER_PAGE, False)
+        page_size = request.args.get('page_size', Config.RESOURCES_PER_PAGE, type=int)
+        if page_size > Config.RESOURCE_MAX_PAGE_SIZE: page_size = Config.RESOURCE_MAX_PAGE_SIZE
+        resource_paginator = Resource.query.paginate(page, page_size, False)
         resource_list = [resource.serialize for resource in resource_paginator.items]
 
     except Exception as e:
@@ -65,7 +67,9 @@ def get_languages():
 
     try:
         page = request.args.get('page', 1, type=int)
-        language_paginator = Language.query.paginate(page, Config.LANGUAGES_PER_PAGE, False)
+        page_size = request.args.get('page_size', Config.LANGUAGES_PER_PAGE, type=int)
+        if page_size > Config.LANGUAGES_MAX_PAGE_SIZE: page_size = Config.LANGUAGES_MAX_PAGE_SIZE
+        language_paginator = Language.query.paginate(page, page_size, False)
         language_list = [language.serialize for language in language_paginator.items]
 
     except Exception as e:

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -47,7 +47,6 @@ def get_resource(id):
 
 
 def get_resources():
-    resources = {}
     try:
         page = request.args.get('page', 1, type=int)
         resource_paginator = Resource.query.paginate(page, Config.RESOURCES_PER_PAGE, False)
@@ -56,7 +55,7 @@ def get_resources():
     except Exception as e:
         print_tb(e.__traceback__)
         print(e)
-
+        resource_list = []
     finally:
         return jsonify(resource_list)
 
@@ -65,11 +64,13 @@ def get_languages():
     languages = {}
 
     try:
-        languages = Language.query.all()
+        page = request.args.get('page', 1, type=int)
+        language_paginator = Language.query.paginate(page, Config.LANGUAGES_PER_PAGE, False)
+        language_list = [language.serialize for language in language_paginator.items]
 
     except Exception as e:
         print_tb(e.__traceback__)
         print(e)
-
+        language_list = []
     finally:
-        return jsonify([language.name for language in languages])
+        return jsonify(language_list)

--- a/app/models.py
+++ b/app/models.py
@@ -99,6 +99,14 @@ class Language(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, unique=True, nullable=False)
 
+    @property
+    def serialize(self):
+        """Return object data in easily serializeable format"""
+        return {
+            'id': self.id,
+            'name': self.name,
+        }
+
     def key(self):
         return self.name
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,14 @@
+class Paginator:
+    def __init__(self, configuration, model, request):
+        self.configuration = configuration
+        self.model = model
+
+        self.page = request.args.get('page', 1, type=int)
+        self.page_size = request.args.get('page_size', configuration.per_page, type=int)
+
+        if self.page_size > configuration.max_page_size:
+            self.page_size = configuration.max_page_size
+
+    @property
+    def items(self):
+        return self.model.query.paginate(self.page, self.page_size, False).items

--- a/configs.py
+++ b/configs.py
@@ -1,5 +1,11 @@
 
 import sys, os
+from dataclasses import dataclass
+
+@dataclass
+class PaginatorConfig:
+    per_page: int = 20
+    max_page_size: int = 100
 
 def get_sys_exec_root_or_drive():
     path = sys.executable
@@ -22,7 +28,7 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI') or alternative_db
     SQL_LITE_DEFAULT = False or (alternative_db != None)
-    RESOURCES_PER_PAGE = 20
-    RESOURCE_MAX_PAGE_SIZE = 100
-    LANGUAGES_PER_PAGE = 20
-    LANGUAGES_MAX_PAGE_SIZE = 100
+
+    # Can pass in changes to defaults, such as PaginatorConfig(per_page=40)
+    RESOURCE_PAGINATOR = PaginatorConfig()
+    LANGUAGE_PAGINATOR = PaginatorConfig()

--- a/configs.py
+++ b/configs.py
@@ -22,3 +22,4 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI') or alternative_db
     SQL_LITE_DEFAULT = False or (alternative_db != None)
+    RESOURCES_PER_PAGE = 20

--- a/configs.py
+++ b/configs.py
@@ -23,3 +23,4 @@ class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI') or alternative_db
     SQL_LITE_DEFAULT = False or (alternative_db != None)
     RESOURCES_PER_PAGE = 20
+    LANGUAGES_PER_PAGE = 20

--- a/configs.py
+++ b/configs.py
@@ -23,4 +23,6 @@ class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI') or alternative_db
     SQL_LITE_DEFAULT = False or (alternative_db != None)
     RESOURCES_PER_PAGE = 20
+    RESOURCE_MAX_PAGE_SIZE = 100
     LANGUAGES_PER_PAGE = 20
+    LANGUAGES_MAX_PAGE_SIZE = 100


### PR DESCRIPTION
Fixes #15 

Pagination is implemented using Flask-SQLAlchemy's built-in paginator. The specific page is requested using a query param called `page`. The request looks like this:
```
GET api/v1/resources?page=1
```
The number of resources per page is included in the Config class, so we can easily change it later. I imagine that eventually we will add a `CATEGORIES_PER_PAGE` and `LANGUAGES_PER_PAGE` as well, for the `GET api/v1/categories` and `GET api/v1/languages` routes.