### PR TITLE
Add and fix linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - 3.6
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script:
+  - pylint app
+# TODO: implement pytests then delete this line and uncomment the next
+#  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - pylint app
+  - flake8 app --statistics --count
 # TODO: implement pytests then delete this line and uncomment the next
 #  - pytest

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,9 @@ from flask_sqlalchemy import SQLAlchemy
 
 try:
     assert version_info >= (3, 7, 0)
-except AssertionError as e:
-    print('Warning Current python version not supported')
-    print('Current python version: {version}'.format(version=version_info))
+except AssertionError:
+    print('Warning Current Python version not supported')
+    print('Current Python version: {version}'.format(version=version_info))
     exit(1)
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ try:
     assert version_info >= (3, 7, 0)
 except AssertionError:
     print('Warning Current Python version not supported')
-    print('Current Python version: {version}'.format(version=version_info))
+    print(f'Current Python version: {version_info}')
     exit(1)
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,16 +1,17 @@
+from sys import version_info
+
+from configs import Config
 from flask import Flask
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
-from sys import version_info
 
 try:
-    assert version_info >= (3,7,0)
+    assert version_info >= (3, 7, 0)
 except AssertionError as e:
     print('Warning Current python version not supported')
     print('Current python version: {version}'.format(version=version_info))
     exit(1)
-    
-from configs import Config
+
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,5 +1,4 @@
+from app.api import routes
 from flask import Blueprint
 
 bp = Blueprint('api', __name__)
-
-from app.api import routes

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,4 +1,3 @@
-from app.api import routes
 from flask import Blueprint
 
 bp = Blueprint('api', __name__)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -25,7 +25,8 @@ def get_resources():
         print(e)
 
     finally:
-        return jsonify([single_resource.serialize for single_resource in resources])
+        return jsonify([single_resource.serialize for
+                        single_resource in resources])
 
 
 def get_languages():

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,9 +1,8 @@
 from traceback import print_tb
 
-from flask import jsonify
-
 from app.api import bp
-from app.models import Resource, Language
+from app.models import Language, Resource
+from flask import jsonify
 
 
 @bp.route('/resources', methods=['GET'])

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,7 +1,10 @@
 import time
+
 import yaml
+
 from sqlalchemy import exc
-from .models import Resource, Category, Language
+
+from .models import Category, Language, Resource
 
 
 def import_resources(db):

--- a/app/cli.py
+++ b/app/cli.py
@@ -27,19 +27,23 @@ def import_resources(db):
         category_dict = {c.key(): c for c in categories_list}
     except AttributeError as e:
         print('-------> EXCEPTION OCCURED DURING DB SETUP')
-        print('-------> Most likely you need to set the "SQLALCHEMY_DATABASE_URI"')
+        print('-------> Most likely you need to set the '
+              '"SQLALCHEMY_DATABASE_URI"')
         print(f'-------> Exception message: {e}')
         return
 
     # Step 4: Create/Update each resource in the db_session
     for resource in unique_resources:
-        resource['category'] = get_category(resource, category_dict)  # Note: modifies the category_dict in place (bad?)
+        # Note: modifies the category_dict in place (bad?)
+        resource['category'] = get_category(resource, category_dict)
+        # Note: modifies the language_dict in place (bad?)
         resource['languages'] = get_languages(resource,
-                                              language_dict)  # Note: modifies the language_dict in place (bad?)
+                                              language_dict)
         existing_resource = existing_resources.get(resource['url'])
 
         if existing_resource:
-            resource == existing_resource or update_resource(resource, existing_resource)
+            resource == existing_resource or \
+                        update_resource(resource, existing_resource)
         else:
             create_resource(resource, db)
 
@@ -48,12 +52,10 @@ def import_resources(db):
     except exc.SQLAlchemyError as e:
         db.session.rollback()
         print('Flask SQLAlchemy Exception:', e)
-        template = "An SQLAlchemy exception of type {0} occurred. Arguments:\n{1!r}"
         print(resource)
     except Exception as e:
         db.session.rollback()
         print('exception', e)
-        template = "An exception of type {0} occurred. Arguments:\n{1!r}"
         print(resource)
 
 
@@ -65,7 +67,8 @@ def remove_duplicates(data):
             resource_dict[resource['url']] = True
             unique_resources.append(resource)
         else:
-            print(f"Encountered a duplicate resource in resources.yml: {resource['url']}")
+            print(f"Encountered a duplicate resource "
+                  f"in resources.yml: {resource['url']}")
     return unique_resources
 
 
@@ -126,7 +129,6 @@ def register(app, db):
     def db_migrate():
         """ migration commands"""
         pass
-
 
     @db_migrate.command()
     def init():

--- a/app/health_check.py
+++ b/app/health_check.py
@@ -5,5 +5,5 @@ def health_database_status():
     try:
         db.session.query("1").from_statement("SELECT 1").all()
         return '<h1>It works.</h1>'
-    except:
+    except Exception:
         return '<h1>Something is broken.</h1>'

--- a/app/models.py
+++ b/app/models.py
@@ -2,16 +2,27 @@ from app import db
 from sqlalchemy_utils import URLType
 
 '''
-    event_id = db.Column('event_id', db.Integer, db.ForeignKey('event.id'), nullable=False)
+    event_id = db.Column('event_id',
+                         db.Integer,
+                         db.ForeignKey('event.id'),
+                         nullable=False)
     event = db.relationship('Event')
-    partner_id = db.Column('partner_id', db.Integer, db.ForeignKey('partner.id'))
+    partner_id = db.Column('partner_id',
+                           db.Integer,
+                           db.ForeignKey('partner.id'))
     partner = db.relationship('Partner')
 
 '''
 
 language_identifier = db.Table('language_identifier',
-                               db.Column('resource_id', db.Integer, db.ForeignKey('resource.id')),
-                               db.Column('language_id', db.Integer, db.ForeignKey('language.id'))
+                               db.Column(
+                                   'resource_id',
+                                   db.Integer,
+                                   db.ForeignKey('resource.id')),
+                               db.Column(
+                                   'language_id',
+                                   db.Integer,
+                                   db.ForeignKey('language.id'))
                                )
 
 
@@ -19,7 +30,9 @@ class Resource(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
     url = db.Column(URLType, nullable=False, unique=True)
-    category_id = db.Column(db.Integer, db.ForeignKey('category.id'), nullable=False)
+    category_id = db.Column(db.Integer,
+                            db.ForeignKey('category.id'),
+                            nullable=False)
     category = db.relationship('Category')
     languages = db.relationship('Language', secondary=language_identifier)
     paid = db.Column(db.Boolean, default=False)
@@ -72,7 +85,11 @@ class Resource(db.Model):
         return hash(self.url)
 
     def __repr__(self):
-        return f"<Resource \n\tName: {self.name}\n\tLanguages: {self.languages}\n\tCategory: {self.category}\n\tURL: {self.url}\n>"
+        return (f"<Resource \n"
+                f"\tName: {self.name}\n"
+                f"\tLanguages: {self.languages}\n"
+                f"\tCategory: {self.category}\n"
+                f"\tURL: {self.url}\n>")
 
 
 class Category(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,5 @@
-from sqlalchemy_utils import URLType
-
 from app import db
+from sqlalchemy_utils import URLType
 
 '''
     event_id = db.Column('event_id', db.Integer, db.ForeignKey('event.id'), nullable=False)

--- a/configs.py
+++ b/configs.py
@@ -1,5 +1,7 @@
 
-import sys, os
+import os
+import sys
+
 
 def get_sys_exec_root_or_drive():
     path = sys.executable

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,8 +1,15 @@
 from __future__ import with_statement
-from alembic import context
-from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
 import logging
+from logging.config import fileConfig
+
+from alembic import context
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from flask import current_app
+from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -13,11 +20,6 @@ config = context.config
 fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-from flask import current_app
 config.set_main_option('sqlalchemy.url',
                        current_app.config.get('SQLALCHEMY_DATABASE_URI'))
 target_metadata = current_app.extensions['migrate'].db.metadata

--- a/migrations/versions/158d296b23b8_.py
+++ b/migrations/versions/158d296b23b8_.py
@@ -5,10 +5,9 @@ Revises: 514a36eb1161
 Create Date: 2018-08-19 10:13:52.714023
 
 """
-from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '158d296b23b8'

--- a/migrations/versions/514a36eb1161_.py
+++ b/migrations/versions/514a36eb1161_.py
@@ -5,10 +5,9 @@ Revises: 59a6f6552b5a
 Create Date: 2018-08-08 22:13:09.695012
 
 """
-from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '514a36eb1161'

--- a/migrations/versions/579c613eff61_initial_add.py
+++ b/migrations/versions/579c613eff61_initial_add.py
@@ -5,9 +5,9 @@ Revises:
 Create Date: 2018-08-04 12:27:33.168421
 
 """
-from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '579c613eff61'

--- a/migrations/versions/59a6f6552b5a_.py
+++ b/migrations/versions/59a6f6552b5a_.py
@@ -5,9 +5,8 @@ Revises: 9dd599c1495d
 Create Date: 2018-08-08 21:59:45.879320
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '59a6f6552b5a'

--- a/migrations/versions/9dd599c1495d_set_default_allow_languages_nullable.py
+++ b/migrations/versions/9dd599c1495d_set_default_allow_languages_nullable.py
@@ -5,9 +5,8 @@ Revises: 579c613eff61
 Create Date: 2018-08-04 12:38:08.601284
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '9dd599c1495d'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ SQLAlchemy==1.2.8
 SQLAlchemy-Utils==0.33.3
 PyYAML==3.13
 psycopg2-binary==2.7.5
-pylint==2.1.1
+flake8==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy==1.2.8
 SQLAlchemy-Utils==0.33.3
 PyYAML==3.13
 psycopg2-binary==2.7.5
+pylint==2.1.1

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
-from app import create_app, db, cli
-from app.models import db, Resource, Category, Language
+from app import cli, create_app, db
+from app.models import Category, Language, Resource, db
 
 app = create_app()
 cli.register(app, db)


### PR DESCRIPTION
* Fixes #12 
* Includes and closes #35
* Switch from `pylint` to `flake8` linting, which includes `pyflakes` (checks for errors) and `pycodestyle` (formerly called `pep8`)
* Fix linting errors, including running `isort`
