### PR TITLE
Fixed formatting to match pagination implementation for resources

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -61,7 +61,6 @@ def get_resources():
 
 
 def get_languages():
-
     try:
         language_paginator = Paginator(Config.LANGUAGE_PAGINATOR, Language, request)
         language_list = [language.serialize for language in language_paginator.items]


### PR DESCRIPTION
Modified the formatting of the implementation for pagination of /languages route (preexisting code) to match the format of the pagination implementation for /resources route. Closes #32.