### PR TITLE
Params for filtering resources on language or category. 

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,3 +2,6 @@ from flask import Blueprint
 
 bp = Blueprint('api', __name__)
 
+# We need to import the routes here so they will
+# bind to the blueprint before the blueprint is registered.
+from app.api import routes  # noqa

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,6 +10,7 @@ from app.models import Language, Resource, Category
 from app import Config
 from app.utils import Paginator
 
+
 # Routes
 @bp.route('/resources', methods=['GET'])
 def resources():
@@ -97,7 +98,9 @@ def get_resources():
         else:
             query = Resource.query
 
-        resource_list = [resource.serialize for resource in resource_paginator.items(query)]
+        resource_list = [
+            resource.serialize for resource in resource_paginator.items(query)
+        ]
 
     except Exception as e:
         print_tb(e.__traceback__)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -15,11 +15,22 @@ def resources():
 def languages():
     return get_languages()
 
+@bp.route('/languages/<lang>', methods=['GET'])
+def language(lang):
+    return get_resources(lang)
 
-def get_resources():
+
+def get_resources(lang=None):
     resources = {}
     try:
-        resources = Resource.query.all()
+        if lang:
+            resources = Resource.query.filter(
+                Resource.languages.any(
+                    Language.name.like(lang)
+                )
+            ).all()
+        else:
+            resources = Resource.query.all()
 
     except Exception as e:
         print_tb(e.__traceback__)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -57,7 +57,6 @@ def get_resources():
 
     The filters are case insensitive.
     """
-    resource_list = []
     try:
         resource_paginator = Paginator(Config.RESOURCE_PAGINATOR, request)
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -2,17 +2,17 @@ from traceback import print_tb
 
 from flask import request
 from flask import jsonify
+from sqlalchemy import and_, func
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from app.api import bp
-from app.models import Language, Resource
+from app.models import Language, Resource, Category
 from app import Config
 from app.utils import Paginator
 
 # Routes
 @bp.route('/resources', methods=['GET'])
 def resources():
-    print("feinsmecker")
     return get_resources()
 
 
@@ -48,18 +48,56 @@ def get_resource(id):
 
 
 def get_resources():
-    try:
-        resource_paginator = Paginator(Config.RESOURCE_PAGINATOR, Resource, request)
-        resource_list = [resource.serialize for resource in resource_paginator.items]
+    """
+    Gets a paginated list of resources.
 
-        lang = request.args.get('lang')
+    If the URL parameters `language` or `category` are found
+    in the request, the list will be filtered by these parameters.
+
+    The filters are case insensitive.
+    """
+    resource_list = []
+    try:
+        resource_paginator = Paginator(Config.RESOURCE_PAGINATOR, request)
+
+        # Fetch the filter params from the url, if they were provided.
+        language = request.args.get('language')
         category = request.args.get('category')
 
-        # Filter out hits that don't match the filter params.
-        if lang:
-            resource_list = [resource for resource in resource_list if lang in resource.serialize_languages]
-        if category:
-            resource_list = [resource for resource in resource_list if category == resource.category.name]
+        # Filter on language
+        if language and not category:
+            query = Resource.query.filter(
+                Resource.languages.any(
+                    Language.name.ilike(language)
+                )
+            )
+
+        # Filter on category
+        elif category and not language:
+            query = Resource.query.filter(
+                Resource.category.has(
+                    func.lower(Category.name) == category.lower()
+                )
+            )
+
+        # Filter on both
+        elif category and language:
+            query = Resource.query.filter(
+                and_(
+                    Resource.languages.any(
+                        Language.name.ilike(language)
+                    ),
+                    Resource.category.has(
+                        func.lower(Category.name) == category.lower()
+                    )
+                )
+            )
+
+        # No filters
+        else:
+            query = Resource.query
+
+        resource_list = [resource.serialize for resource in resource_paginator.items(query)]
 
     except Exception as e:
         print_tb(e.__traceback__)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,6 @@
 class Paginator:
-    def __init__(self, configuration, model, request):
+    def __init__(self, configuration, request):
         self.configuration = configuration
-        self.model = model
 
         self.page = request.args.get('page', 1, type=int)
         self.page_size = request.args.get('page_size', configuration.per_page, type=int)
@@ -9,6 +8,5 @@ class Paginator:
         if self.page_size > configuration.max_page_size:
             self.page_size = configuration.max_page_size
 
-    @property
-    def items(self):
-        return self.model.query.paginate(self.page, self.page_size, False).items
+    def items(self, query):
+        return query.paginate(self.page, self.page_size, False).items


### PR DESCRIPTION
Opening a new pull request because the other one fell victim to the GitHub problems that have been happening today and yesterday.

This PR solves #29, allowing you to filter GET requests to the resources endpoint by language, category, or both. The requests are still paginated in the same way, with the filtering being applied _before_ the pagination is done. All filters are caps insensitive.