### PR TITLE
Modified implementation of getting languages route

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -117,8 +117,12 @@ def get_resources():
 
 def get_languages():
     try:
-        language_paginator = Paginator(Config.LANGUAGE_PAGINATOR, Language, request)
-        language_list = [language.serialize for language in language_paginator.items]
+        language_paginator = Paginator(Config.LANGUAGE_PAGINATOR, request)
+        query = Language.query
+
+        language_list = [
+            language.serialize for language in language_paginator.items(query)
+        ]
 
     except Exception as e:
         print_tb(e.__traceback__)


### PR DESCRIPTION
Refactored the implementation for pagination of /languages route to match that of the /resources route due to changes in paginator interface. Updated code passes in query to `language_paginator.items` and removes `Language` argument from Paginator constructor. Closes #32.