### PR TITLE
Fix encoding in import_resources

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,7 +9,7 @@ from .models import Category, Language, Resource
 
 def import_resources(db):
     # Step 1: Get data
-    with open('resources.yml', 'r') as f:
+    with open('resources.yml', encoding='utf-8') as f:
         data = yaml.load(f)
 
     # Step 2: Uniquify resources


### PR DESCRIPTION
There was a byte (0x9d) in resources.yml that broke my import on my Windows VM. Not sure if this was recently added when I added all the new resources or what. The first google search says this should fix it.