### PR TITLE
Add linux to readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contribution Guide
+
+Firstly, thank you for considering making a contribution to our project! It's people like you that make Operation Code such a great community.
+
+We're an open source project and we love receiving contributions from our community - you! There are many ways to contribute to our projects, from writing tutorials or blog posts, improving documentation, submitting bug reports or feature requests, or writing code which can be merged into any of our repositories.
+
+The team at Operation Code urges all contributors to join our Slack team. Participating in discussions with the community on our Slack channel, is the best way to run new ideas by the team, and is the best place to get help. You can get an invitation to our Slack channel by [requestion to join Operation Code](https://operationcode.org/join). Once in our Slack team, simply type: '/open #oc-projects' and then click enter. Feel free to ask for help; everyone is a beginner at first :smile_cat:!
+
+**This guide assumes that you have some at least some familiarity with submitting a pull request on Github. If you don't, that's ok too though. Simply start by reading Github's own user documentation on how to fork a repository, and make your own edits. That documentation is [here](https://help.github.com/articles/about-pull-requests/) and [here](https://help.github.com/articles/creating-a-pull-request/). 3rd party tutorials on Git/Github can be found [here](https://medium.freecodecamp.org/what-is-git-and-how-to-use-it-c341b049ae61) and [here](https://medium.freecodecamp.org/how-to-use-git-efficiently-54320a236369?source=linkShare-e41cd5edcdac-1535829065)**
+
+
+## Development Workflow
+
+### Dependencies
+
+The primary technologies used in this project are:
+
+- [Python](https://www.python.org)
+- [Flask](http://flask.pocoo.org)
+- [Postgres](https://www.postgresql.org)
+
+To work on the codebase for this project, you will need to have those dependencies installed.
+
+
+### Finding An Issue
+
+<details>
+	<summary>Click to Expand</summary>
+<ul>
+<li> After installing the listed dependencies, you can get to work coding on this project. A listing of this repo's can be found <a href="https://github.com/OperationCode/resources_api/issues">here</a></li>
+<li> Go to the issues page for this repo, [here]() and browse for an issue that you would like to work on. Don't be afraid to ask for help or clarification.</li>
+<li> Once you have found an issue, leave a comment stating that you'd like to work on the issue. Once the issue is assigned to you, you may start working on it. </li>
+</ul>
+</details>
+
+### Working On Your Issue
+
+<details>
+	<summary>Click to Expand</summary>
+
+* After forking this repository to your own github account, and cloning it to your dev environment, you can now create a new branch on your machine. It's wise to name this branch, after the issue you are trying to fix, or the feature you are trying to add.
+
+	```bash
+	git checkout -b creatingContributionGuide
+	```
+
+* In the example above, I have created a new branch, named "creatingContributionGuide". This command also "checks out" the branch, meaning git now knows that is the branch you are working on. You can check what branch you are working on by using the `branch` command.
+
+	```bash
+	git branch
+	```
+* Following my example, `git branch`, would output "creatingContributionGuide" in my terminal.
+
+* Once you have finished working on your issue, push your changes to your own github repo, and then submit a pull request.
+
+* To return to your main `master` branch, type the follwing command in your terminal.
+
+	```bash
+	git checkout master
+	```
+</details>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,69 @@ This project provides an API for storing and retrieving learning resources that 
 
 ## Getting Started
 
-First, you'll need to configure a database. Once this project is deployed, we'll be using PostgreSQL. To set up a psql instance locally, follow the instructions for your OS:
+If this is your first project using GitHub, Python, or pip follow these steps first:
+1. Install [Git](https://git-scm.com/downloads).
+- Choose your OS from the website and follow the prompts.  This installs Git and the Bash Terminal on your machine.
+- Extra: [Git Documentation](https://git-scm.com/doc) for more information on Git.
+2. Install and Setup Python.
+- [Windows Users](https://docs.python.org/3/using/windows.html)
+- [Mac Users](https://docs.python.org/3/using/mac.html)
+3. Install [pip](https://pip.pypa.io/en/stable/installing/).
+4. Sometimes these installs can be tricky.  If you get stuck ask for help in the Slack [#oc-python-projects](https://operation-code.slack.com/messages/C7NJLCCMB) channel! 
+5. [Fork](https://help.github.com/articles/fork-a-repo/) this repository.
+6. [Clone](https://help.github.com/articles/cloning-a-repository/) this repository in the Git Bash terminal.
+- Navigate to where you would like to clone a fork of your repository. `cd \path\to\directory`
+- Clone your fork of the project `git clone {project_url} resources`
 
-### Windows setup
 
-Coming Soon!
+Next, you'll need to configure a database. Once this project is deployed, we'll be using [PostgreSQL](https://www.postgresql.org/docs/). To set up a psql instance locally, follow the instructions for your OS:
+
+### Windows Setup
+<details>
+<summary>Click to Expand</summary>
+
+1. Setup up paths and system variables:   
+- Search --> Edit the [system environment variables](https://docs.microsoft.com/en-us/windows/desktop/shell/user-environment-variables) --> Environment Variables... --> Path --> Edit... --> New --> Enter `C:\ProgramData\chocolatey\bin` --> OK
+- New --> `C:\Program Files\PostgreSQL\10\bin` --> OK
+2. Set the System Variables.
+- Click the bottom New... -->
+- Connection Variable:
+    - Variable Name: `SQLALCHEMY_DATABASE_URI`
+    - Variable Value: `postgresql://aaron:password@127.0.0.1:5432/resources` (instead of aaron and password put what user name and password you want to use for postgresql) 
+- FLASK_APP Variable:
+    - Variable name: `FLASK_APP`
+    - Variable Value: `run.py`
+    - Optionally, enable debugging by setting the environment to development with the Variable Value: `development`
+3. Close out of Environment Variables and System Properites.
+4. Start your administrative shell. `ctrl + x` --> Windows Powershell (Admin).
+- **Make sure you use the _admin powershell_ throughout all the steps.**
+5. [Install Chocolatey](https://chocolatey.org/docs/installation#installing-chocolatey) if you do not already have it installed.
+6. In your powershell (admin), run `choco install postgresql10`. Follow the prompts.
+7. Upgrade postgresql: `choco upgrade postgresql`.
+8. Start postgres: `psql -U postgres` you will see postgres-# in the terminal.
+9. Create your user with `CREATE USER name WITH PASSWORD 'password';` The terminal will print CREATE ROLE.
+10. Alter your role with permission to create a database with `ALTER USER name WITH CREATEDB CREATEROLE;` The terminal will print ALTER ROLE
+11. Check everything is in order with `\du`. The terminal will print a table with Role name, Atrributes, and Member columns. If your user is listed you are good to go.
+12. Create a database with: `CREATE DATABASE resources OWNER name;`.
+13. Connect to the resources database: `\c resources`. If you see `resources =>` you are ready to move on to the next steps.
+14. Navigate to the cloned repo directory `cd \path\to\resources`. (see step 6 under getting started)
+15. Install virtualenv if you do not have it. `pip install virtualenv`.
+16. [Create a virtual environment](https://docs.python.org/3/library/venv.html) called venv `python -m virtualenv venv`.
+17. Set Execution Policy to unrestricted `Set-ExecutionPolicy Unrestricted -Force`
+18. Activate the virtual environment `venv\Scripts\Activate.ps1`
+19. Install the required dependencies `pip install pipenv`
+20. Install --dev `pip install --dev`.
+21. Create the tables in your database with `flask db-migrate create-tables`
+22. Tell flask that your database is up to date with `flask db stamp head`
+23. Populate your database with the resources `flask db-migrate init`
+24. Start your development server with `flask run` and you're ready to go!
+25. Check your work: Open your browser and go to `localhost:5000/api/v1/resources`. You should see a list of objects. 
+</details>
 
 ### Mac setup
+
+<details>
+<summary>Click to Expand</summary>
 
 1. [Install Homebrew](https://brew.sh/) if you do not already have it installed
 2. In your terminal, run `brew install postgresql`
@@ -25,24 +81,45 @@ Note: if you try to use the same username as the user you are logged in as, you 
 ```
 export SQLALCHEMY_DATABASE_URI=postgresql://aaron:password@127.0.0.1:5432/resources
 ```
-8. Clone your fork of the project `git clone {project_url} resources`
-9. Change directory into the project `cd resources`
-10. Create a virtual environment called venv `python -m virtualenv venv`
+8. Navigate to the cloned repo directory `cd \path\to\resources`. (see step 6 under getting started)
+9. Install virtualenv if you do not have it. `pip install virtualenv`.
+10. [Create a virtual environment](https://docs.python.org/3/library/venv.html) called venv `python -m virtualenv venv`.
 11. Activate virtual environment `source venv/bin/activate`
-12. Install the required dependencies `pip install -r requirements.txt`
-13. Set the FLASK_APP environment variable `export FLASK_APP=run.py` or `ENV:FLASK_APP = "run.py"`
-14. Optionally, enable debugging by setting the environment to development with `export FLASK_ENV=development`
-15. Create the tables in your database with `flask db_migrate create_tables`
-16. Tell flask that your database is up to date with `flask db stamp head`
-17. Populate your database with the resources `flask db_migrate init`
-18. Start your development server with `flask run` and you're ready to go!
+12. Install the required dependencies `pip install pipenv`.
+13. Install --dev `pip install --dev`.
+14. Set the FLASK_APP environment variable `export FLASK_APP=run.py` or `ENV:FLASK_APP = "run.py"`
+15. Optionally, enable debugging by setting the environment to development with `export FLASK_ENV=development`
+16. Create the tables in your database with `flask db-migrate create-tables`
+17. Tell flask that your database is up to date with `flask db stamp head`
+18. Populate your database with the resources `flask db-migrate init`
+19. Start your development server with `flask run` and you're ready to go!
+</details>
+
+### Linux Setup
+<details>
+<summary>Click to Expand</summary>
+
+1. Install postgresql. On A Debian or Ubuntu based system(Linux Mint, elementaryOS, ect), this would look like
+
+	```bash
+	sudo apt install postgresql postgresql-contrib
+	#postgresql-contrib is an opptional package that addes some addition utitilities to make using postgresql easier
+	```
+2. On an Ubuntu based system, Postgresql will automatically be enabled when installing it this way. 
+3. Ensure postgrs is running: `psql -V`
+4. Create your user with `sudo -u postgres createuser -d -P --interactive`. This will give you a prompt to create a new user. It will ask for the name of the role to add. This is your username. Then it will ask for your password. You must pick a username, that is different from an existing login name on your computer. For example, if you are logged into your computer as "aaron", pick a name other than "aaron". The prompt will than ask if you want to be a superuser. Just press "y", and enter.
+5. Create a database with `sudo -u postgres createdb resources -U aaron` ("resources" is the name we are giving to the database. You can call it whatever you'd like.Make sure to replace "aaron", with whatever username you gave to your postgres user.)
+6. Now you should be able to scroll up on this page, and start following along with the Mac setup instructions, starting at step #7.
+</details>
 
 
 ## Development Notes
 
 If you make changes to the models.py or other schemas, you need to run a migration and upgrade again:
 
-1. Set the FLASK_APP environment variable `export FLASK_APP=run.py` or `ENV:FLASK_APP = "run.py"`
+1. Set the FLASK_APP environment variable 
+- Mac OS: `export FLASK_APP=run.py` or `ENV:FLASK_APP = "run.py"`
+- Windows: see step 1 & 2 under Windows Setup
 2. Run the migration `flask db migrate`
 3. Upgrade to the latest migration `flask db upgrade`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-﻿alembic==0.9.9
-Flask==1.0.2
-Flask-Migrate==2.1.1
-Flask-SQLAlchemy==2.3.2
-SQLAlchemy==1.2.12
-SQLAlchemy-Utils==0.33.3
-PyYAML==3.13
-psycopg2-binary==2.7.5
-flake8==3.5.0


### PR DESCRIPTION
 #58 
I added Linux setup steps to the readme.

I also added collapsible boxes for the setup instructions. In my opinion it looked a little unwieldy looking at all 3 of them. It's an easy change if someone wants to get rid of them though.

At the top of the doc there are links for setting up python for mac and windows. I almost added the link for the linux docs, but most distros have python preinstalled by default, so I left that out. 