### PR TITLE
Add create and update timestamps to Resource objects

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 FLASK_APP=run.py
-SQLALCHEMY_DATABASE_URI=postgresql://user_name:change_password@127.0.0.1:5432/resources
+SQLALCHEMY_DATABASE_URI=postgresql://aaron:getmein@127.0.0.1:5432/resources
 FLASK_SKIP_DOTENV=1
+FLASK_ENV=development

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,7 @@
 from app import db
 from sqlalchemy_utils import URLType
+from sqlalchemy import DateTime
+from sqlalchemy.sql import func
 
 
 language_identifier = db.Table('language_identifier',
@@ -28,6 +30,8 @@ class Resource(db.Model):
     upvotes = db.Column(db.INTEGER, default=0)
     downvotes = db.Column(db.INTEGER, default=0)
     times_clicked = db.Column(db.INTEGER, default=0)
+    created_at = db.Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = db.Column(DateTime(timezone=True), onupdate=func.now())
 
     @property
     def serialize(self):

--- a/app/utils.py
+++ b/app/utils.py
@@ -16,15 +16,15 @@ class Paginator:
         return query.paginate(self.page, self.page_size, False).items
 
 
-def standardize_response(data, errors, status):
+def standardize_response(data, errors, status, status_code=200):
     resp = {
         "status": status,
         "apiVersion": API_VERSION
     }
-    if data:
+    if data is not None:
         resp["data"] = data
     elif errors:
         resp["errors"] = errors
     else:
         resp["errors"] = [{"code": "something-went-wrong"}]
-    return jsonify(resp)
+    return jsonify(resp), status_code

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import pytest
 from app import create_app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 import pytest
+import tempfile
+from app import db
 from app import create_app
 
 TESTDB = 'test_project.db'
@@ -19,5 +21,16 @@ def app():
 
 @pytest.fixture(scope='module')
 def client(app):
+    db_fd, app.config['DATABASE'] = tempfile.mkstemp()
+
+    app.config['SQLALCHEMY_DATABASE_URI'] = TEST_DATABASE_URI
+
+    with app.app_context():
+        db.create_all()
+
     client = app.test_client()
-    return client
+
+    yield client
+
+    os.close(db_fd)
+    os.unlink(app.config['DATABASE'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,21 @@ import tempfile
 import pytest
 from app import create_app
 
+TESTDB = 'test_project.db'
+TESTDB_PATH = "tests/data/{}".format(TESTDB)
+TEST_DATABASE_URI = 'sqlite:///' + TESTDB_PATH
+
+
+ALEMBIC_CONFIG = 'migrations/alembic.ini'
+
+
 @pytest.fixture(scope='module')
 def app():
     app = create_app()
+    app.testing = True
     return app
+
+@pytest.fixture(scope='module')
+def client(app):
+    client = app.test_client()
+    return client

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1,4 +1,5 @@
 import pytest
+from tests import conftest
 from app.models import Resource, Language, Category
 
 
@@ -10,8 +11,6 @@ def test_does_nothing():
     """
     assert(1 == 1)
 
-def test_empty_db(client):
-    """Start with a blank database."""
-
-    rv = client.get('/')
-    assert b'No entries here so far' in rv.data
+def test_get_resources(app, client):
+    resources = client.get('api/v1/resources')
+    assert(resources.status_code == 200)

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1,16 +1,171 @@
 import pytest
 from tests import conftest
 from app.models import Resource, Language, Category
+from configs import PaginatorConfig
+from app.cli import import_resources
 
 
-def test_does_nothing():
-    """
-    GIVEN a User model
-    WHEN a new User is created
-    THEN check the email, hashed_password, authenticated, and role fields are defined correctly
-    """
-    assert(1 == 1)
+##########################################
+## Tests
+##########################################
 
-def test_get_resources(app, client):
-    resources = client.get('api/v1/resources')
-    assert(resources.status_code == 200)
+# TODO: We need negative unit tests (what happens when bad data is sent)
+
+def test_getters(app, session, db):
+    # Importing the data takes a rather long time, so import it once
+    # here for all the getters that require pages of resources
+    import_resources(db)
+    client = app.test_client()
+
+    # Actually conduct all the tests in helper functions
+    get_resources_test(app, session, db, client)
+    paginator_test(app, session, db, client)
+    filters_test(app, session, db, client)
+    languages_test(app, session, db, client)
+    categories_test(app, session, db, client)
+
+
+def test_create_resource(app, session, db):
+    client = app.test_client()
+
+    response = create_resource(client)
+    assert(response.status_code == 200)
+    assert(isinstance(response.json['data'].get('id'), int))
+    assert(response.json['data'].get('name') == "Some Name")
+
+
+def test_update_resource(app, session, db):
+    client = app.test_client()
+
+    response = create_resource(client)
+
+    id = response.json['data'].get('id')
+    assert(isinstance(id, int))
+
+    response = client.put(f"/api/v1/resources/{id}", json={
+        "name": "New name"
+    })
+
+    assert(response.status_code == 200)
+    assert(response.json['data'].get('name') == "New name")
+
+
+##########################################
+## Helpers
+##########################################
+
+def get_resources_test(app, session, db, client):
+    response = client.get('api/v1/resources')
+
+    # Status should be OK
+    assert(response.status_code == 200)
+
+    resources = response.json
+
+    # Default page size shouold be specified in PaginatorConfig
+    assert(len(resources['data']) == PaginatorConfig.per_page)
+    check_resources(resources['data'])
+
+
+def get_single_resource_test(app, session, db, client):
+    response = client.get('api/v1/resources/5')
+
+    # Status should be OK
+    assert(response.status_code == 200)
+
+    resource = response.json
+
+    check_resources([resources['data']])
+    assert(resources['data'].get('id') == 5)
+
+
+
+def paginator_test(app, session, db, client):
+    # Test page size
+    response = client.get('api/v1/resources?page_size=1')
+    assert(len(response.json['data']) == 1)
+    response = client.get('api/v1/resources?page_size=5')
+    assert(len(response.json['data']) == 5)
+    response = client.get('api/v1/resources?page_size=10')
+    assert(len(response.json['data']) == 10)
+    response = client.get('api/v1/resources?page_size=100')
+    assert(len(response.json['data']) == 100)
+
+    # Test pages different and sequential
+    first_page_resource = response.json['data'][0]
+    assert(first_page_resource.get('id') == 1)
+    response = client.get('api/v1/resources?page_size=100&page=2')
+    second_page_resource = response.json['data'][0]
+    assert(second_page_resource.get('id') == 101)
+    response = client.get('api/v1/resources?page_size=100&page=3')
+    third_page_resource = response.json['data'][0]
+    assert(third_page_resource.get('id') == 201)
+
+    # Test bigger than max page size
+    too_long = PaginatorConfig.max_page_size + 1
+    response = client.get(f"api/v1/resources?page_size={too_long}")
+    assert(len(response.json['data']) == PaginatorConfig.max_page_size)
+
+    # Test farther than last page
+    too_far = 99999999
+    response = client.get(f"api/v1/resources?page_size=100&page={too_far}")
+    assert(len(response.json['data']) == 0)
+
+
+def filters_test(app, session, db, client):
+    # Filter by language
+    response = client.get('api/v1/resources?language=python')
+
+    for resource in response.json['data']:
+        assert(type(resource.get('languages')) is list)
+        assert('Python' in resource.get('languages'))
+
+    # Filter by category
+    response = client.get('api/v1/resources?category=Back%20End%20Dev')
+
+    for resource in response.json['data']:
+        assert(resource.get('category') == "Back End Dev")
+
+    # TODO: Filter by updated_after
+    # (Need to figure out how to manually set last_updated and created_at)
+
+
+def languages_test(app, session, db, client):
+    response = client.get('api/v1/languages')
+
+    for language in response.json['data']:
+        assert(isinstance(language.get('id'), int))
+        assert(isinstance(language.get('name'), str))
+        assert(len(language.get('name')) > 0)
+
+
+def categories_test(app, session, db, client):
+    response = client.get('api/v1/categories')
+
+    for category in response.json['data']:
+        assert(isinstance(category.get('id'), int))
+        assert(isinstance(category.get('name'), str))
+        assert(len(category.get('name')) > 0)
+
+
+def check_resources(resources):
+    # Each resource should have a name, url, languages and category
+    for resource in resources:
+        assert(isinstance(resource.get('name'), str))
+        assert(resource.get('name') != "")
+        assert(isinstance(resource.get('url'), str))
+        assert(resource.get('url') != "")
+        assert(isinstance(resource.get('category'), str))
+        assert(resource.get('category') != "")
+        assert(type(resource.get('languages')) is list)
+
+
+def create_resource(client):
+    return client.post('/api/v1/resources', json={
+        "name": "Some Name",
+        "url": "http://example.org/",
+        "category": "New Category",
+        "languages": ["Python", "New Language"],
+        "paid": False,
+        "notes": "Some notes"
+    })

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -9,3 +9,9 @@ def test_does_nothing():
     THEN check the email, hashed_password, authenticated, and role fields are defined correctly
     """
     assert(1 == 1)
+
+def test_empty_db(client):
+    """Start with a blank database."""
+
+    rv = client.get('/')
+    assert b'No entries here so far' in rv.data


### PR DESCRIPTION
This addresses #66.

I am thinking we'll probably need to add a parameter to the `GET /resources` route so that the front end can actually query for resources based on the `created_at` or `last_updated` data. Let me know if you want to see that as part of this PR. 

I'm willing to have a discussion about whether we should include these timestamps in the data returned by all requests (I wasn't sure so I decided to not include it until we can have a discussion about it).