### PR TITLE
Add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 env:
   global:
-    - CC_TEST_REPORTER_ID=147d129d98f3d606ce69bc151bbeded40dc684fe11e0f5a831f11f6b36680b22
     - SQLALCHEMY_DATABASE_URI="sqlite:///:memory:"
 language: python
 sudo: required
 dist: xenial
 python: "3.7"
+
 services:
   - docker
 
@@ -23,6 +23,7 @@ before_script:
   - sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - 'make bg'
   - docker ps -a
   - sleep 30
@@ -33,7 +34,6 @@ script:
   - 'make lint'
 
 after_script:
-  - coverage xml
+  - docker-compose run resources-api coverage xml
   - docker-compose -f docker-compose.yml down
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
-
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then ./cc-test-reporter -r 147d129d98f3d606ce69bc151bbeded40dc684fe11e0f5a831f11f6b36680b22 after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ routes:
 test: build
 	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} py.test --cov=app/ tests/
 
+.PHONY: test-coverage
+test-coverage:
+	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} py.test --cov-report html --cov=app/ tests/
+
 .PHONY: lint
 lint:
 	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} flake8 app --statistics --count

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,18 +1,9 @@
-from sys import version_info
-
 from configs import Config
 from flask import Flask
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-
-try:
-    assert version_info >= (3, 7, 0)
-except AssertionError:
-    print('Warning Current Python version not supported')
-    print('Current Python version: {version}'.format(version=version_info))
-    exit(1)
 
 
 db = SQLAlchemy()

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -85,7 +85,7 @@ def apikey():
         logger.info(apikey.serialize)
         return standardize_response(payload=dict(data=apikey.serialize))
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
 
@@ -97,11 +97,11 @@ def get_resource(id):
 
     except MultipleResultsFound as e:
         print_tb(e.__traceback__)
-        logger.error(e)
+        logger.exception(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)
-        logger.error(e)
+        logger.exception(e)
         return redirect('/404')
 
     if resource:
@@ -152,7 +152,7 @@ def get_resources():
                 raise Exception("updated_after greater than today's date")
             uaDate = uaDate.strftime("%Y-%m-%d")
         except Exception as e:
-            logger.error(e)
+            logger.exception(e)
             message = 'The value for "updated_after" is invalid'
             res = dict(errors=[{'code': 'unprocessable-entity', 'message': message}])
             return standardize_response(payload=res, status_code=422)
@@ -169,7 +169,7 @@ def get_resources():
             resource.serialize for resource in resource_paginator.items(q)
         ]
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
     return standardize_response(payload=dict(data=resource_list))
@@ -184,7 +184,7 @@ def get_languages():
             language.serialize for language in language_paginator.items(query)
         ]
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
     return standardize_response(payload=dict(data=language_list))
@@ -200,7 +200,7 @@ def get_categories():
         ]
 
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
     return standardize_response(payload=dict(data=category_list))
@@ -232,16 +232,16 @@ def update_votes(id, vote_direction):
 
     except MultipleResultsFound as e:
         print_tb(e.__traceback__)
-        logger.error(e)
+        logger.exception(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)
-        logger.error(e)
+        logger.exception(e)
         return redirect('/404')
 
     except Exception as e:
         print_tb(e.__traceback__)
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
     initial_count = getattr(resource, vote_direction)
@@ -281,7 +281,7 @@ def set_resource(id, json, db):
             payload=dict(data=resource.serialize)
             )
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
 
@@ -301,7 +301,7 @@ def create_resource(json, db):
 
         return standardize_response(payload=dict(data=new_resource.serialize))
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)
 
 
@@ -321,5 +321,5 @@ def create_new_apikey(email):
 
         return standardize_response(payload=dict(data=new_key.serialize))
     except Exception as e:
-        logger.error(e)
+        logger.exception(e)
         return standardize_response(status_code=500)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -72,7 +72,8 @@ def apikey():
     is_oc_member = is_user_oc_member(email, password)
 
     if not is_oc_member:
-        return standardize_response(status_code=401)
+        payload = dict(errors=["Invalid username or password"])
+        return standardize_response(payload=payload, status_code=401)
 
     try:
         # We need to check the database for an existing key
@@ -96,17 +97,17 @@ def get_resource(id):
 
     except MultipleResultsFound as e:
         print_tb(e.__traceback__)
-        print(e)
+        logger.error(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)
-        print(e)
+        logger.error(e)
+        return redirect('/404')
 
-    finally:
-        if resource:
-            return standardize_response(payload=dict(data=(resource.serialize)))
-        else:
-            return standardize_response(status_code=404)
+    if resource:
+        return standardize_response(payload=dict(data=(resource.serialize)))
+
+    redirect('/404')
 
 
 def get_resources():
@@ -199,11 +200,10 @@ def get_categories():
         ]
 
     except Exception as e:
-        print_tb(e.__traceback__)
-        print(e)
-        category_list = []
-    finally:
-        return standardize_response(payload=dict(data=category_list))
+        logger.error(e)
+        return standardize_response(status_code=500)
+
+    return standardize_response(payload=dict(data=category_list))
 
 
 def get_attributes(json):
@@ -232,16 +232,16 @@ def update_votes(id, vote_direction):
 
     except MultipleResultsFound as e:
         print_tb(e.__traceback__)
-        print(e)
+        logger.error(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)
-        print(e)
+        logger.error(e)
         return redirect('/404')
 
     except Exception as e:
         print_tb(e.__traceback__)
-        print(e)
+        logger.error(e)
         return standardize_response(status_code=500)
 
     initial_count = getattr(resource, vote_direction)
@@ -282,7 +282,7 @@ def set_resource(id, json, db):
             )
     except Exception as e:
         logger.error(e)
-        return standardize_response(status_code=400)
+        return standardize_response(status_code=500)
 
 
 def create_resource(json, db):

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -154,7 +154,7 @@ def get_resources():
         except Exception as e:
             logger.error(e)
             message = 'The value for "updated_after" is invalid'
-            res = dict(error=[{"code": "bad-value", "message": message}])
+            res = dict(errors=[{'code': 'unprocessable-entity', 'message': message}])
             return standardize_response(payload=res, status_code=422)
 
         q = q.filter(

--- a/app/health_check.py
+++ b/app/health_check.py
@@ -1,9 +1,0 @@
-from app import db
-
-
-def health_database_status():
-    try:
-        db.session.query("1").from_statement("SELECT 1").all()
-        return '<h1>It works.</h1>'
-    except Exception:
-        return '<h1>Something is broken.</h1>'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,29 +137,29 @@ def fake_invalid_auth_from_oc(mocker):
 @pytest.fixture(scope='function')
 def fake_items_error(mocker):
     """
-    Intentionally raises an error to test error response is correct
+    Mocks an exception being raised during pagination to test error handling
     """
     def items():
         raise Exception("An \"unexpected\" Exception was raised!")
 
-    mocker.patch('app.utils.Paginator.items', return_value=items, side_effect=items)
+    mocker.patch('app.utils.Paginator.items', side_effect=items)
 
 @pytest.fixture(scope='function')
 def fake_commit_error(mocker):
     """
-    Intentionally raises an error to test error response is correct
+    Mocks an exception being raised during a db commit to test error handling
     """
     def commit():
         raise Exception("An \"unexpected\" Exception was raised!")
 
-    mocker.patch('app.db.session.commit', return_value=commit, side_effect=commit)
+    mocker.patch('app.db.session.commit', side_effect=commit)
 
 @pytest.fixture(scope='function')
 def fake_key_query_error(mocker):
     """
-    Intentionally raises an error to test error response is correct
+    Mocks an exception being raised during a query to test error handling
     """
     def key_query():
         raise Exception()
 
-    mocker.patch('app.models.Key.query', return_value=key_query, side_effect=key_query)
+    mocker.patch('app.models.Key.query', side_effect=key_query)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,12 +116,50 @@ def fake_auth_from_oc(mocker):
     mocker.patch("requests.post", return_value=FakeExternalResponse())
 
 @pytest.fixture(scope='function')
-def fake_error(mocker):
+def fake_invalid_auth_from_oc(mocker):
+    """
+    Changes the return value of requests.post to be a custom response
+    object so that we aren't validating external APIs in our unit tests
+    """
+    class ExternalApiRequest(object):
+        @classmethod
+        def post(cls):
+            return FakeExternalResponse()
+
+    class FakeExternalResponse(object):
+        @classmethod
+        def json(self):
+            # Mock an error returned from the OC backend
+            return {'error': 'Invalid Email or password.'}
+
+    mocker.patch("requests.post", return_value=FakeExternalResponse())
+
+@pytest.fixture(scope='function')
+def fake_items_error(mocker):
     """
     Intentionally raises an error to test error response is correct
     """
-    class RaisesError(object):
-        def __init__(self):
-            raise Exception("An \"unexpected\" Exception was raised!")
+    def items():
+        raise Exception("An \"unexpected\" Exception was raised!")
 
-    mocker.patch("request.args", return_value=RaisesError())
+    mocker.patch('app.utils.Paginator.items', return_value=items, side_effect=items)
+
+@pytest.fixture(scope='function')
+def fake_commit_error(mocker):
+    """
+    Intentionally raises an error to test error response is correct
+    """
+    def commit():
+        raise Exception("An \"unexpected\" Exception was raised!")
+
+    mocker.patch('app.db.session.commit', return_value=commit, side_effect=commit)
+
+@pytest.fixture(scope='function')
+def fake_key_query_error(mocker):
+    """
+    Intentionally raises an error to test error response is correct
+    """
+    def key_query():
+        raise Exception()
+
+    mocker.patch('app.models.Key.query', return_value=key_query, side_effect=key_query)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,3 +114,14 @@ def fake_auth_from_oc(mocker):
             return {'token': 'superlegittoken'}
 
     mocker.patch("requests.post", return_value=FakeExternalResponse())
+
+@pytest.fixture(scope='function')
+def fake_error(mocker):
+    """
+    Intentionally raises an error to test error response is correct
+    """
+    class RaisesError(object):
+        def __init__(self):
+            raise Exception("An \"unexpected\" Exception was raised!")
+
+    mocker.patch("request.args", return_value=RaisesError())

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1,0 +1,7 @@
+import pytest
+from tests import conftest
+
+def test_internal_server_error_handler(module_client, module_db, fake_error):
+    client = module_client
+
+    self.assertRaises(Exception, client.get('api/v1/resources'))

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1,7 +1,0 @@
-import pytest
-from tests import conftest
-
-def test_internal_server_error_handler(module_client, module_db, fake_error):
-    client = module_client
-
-    self.assertRaises(Exception, client.get('api/v1/resources'))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,91 @@
+import pytest
+from tests import conftest
+from app.models import Resource, Language, Category, Key
+from datetime import datetime
+
+def test_resource():
+    resource = Resource(
+        name='name',
+        url='https://resource.url',
+        category=Category(name='Category'),
+        languages=[Language(name='language')],
+        paid=False,
+        notes='Some notes'
+    )
+
+    assert (resource.key() == 'https://resource.url')
+    assert (resource.__hash__() == hash('https://resource.url'))
+    assert (resource.__repr__() == f"<Resource \n"
+        f"\tName: name\n"
+        f"\tLanguages: [<Language language>]\n"
+        f"\tCategory: <Category Category>\n"
+        f"\tURL: https://resource.url\n>")
+
+    assert (resource.serialize == {
+        'id': None,
+        'name': 'name',
+        'url': 'https://resource.url',
+        'category': 'Category',
+        'languages': ['language'],
+        'paid': False,
+        'notes': 'Some notes',
+        'upvotes': None,
+        'downvotes': None,
+        'times_clicked': None,
+        'created_at': '',
+        'last_updated': ''
+    })
+
+    # Test equality
+    resource_copy = resource
+    assert (resource == resource_copy)
+
+    not_copy = Resource(name='different name')
+    assert (resource != not_copy)
+    not_copy.name = 'name'
+    not_copy.url='https://notresource.url'
+    assert (resource != not_copy)
+    not_copy.url='https://resource.url'
+    assert (resource != not_copy)
+    not_copy.paid=True
+    assert (resource != not_copy)
+    not_copy.paid=False
+    not_copy.notes='Some other notes'
+    assert (resource != not_copy)
+    not_copy.notes='Some notes'
+    not_copy.category='Different Category'
+    assert (resource != not_copy)
+    not_copy.category=Category(name='Category')
+    not_copy.languages=["different language"]
+    assert (resource != not_copy)
+    not_copy.languages=[Language(name='language')]
+    assert (resource == not_copy)
+    assert (resource != 1)
+
+def test_category():
+    category = Category(name="Category")
+    assert (category.__hash__() == hash('Category'))
+    assert (category.__repr__() == f"<Category Category>")
+    assert (category != 1)
+    assert (category == category)
+
+def test_language():
+    language = Language(name="Language")
+    assert (language.__hash__() == hash('Language'))
+    assert (language.__repr__() == f"<Language Language>")
+    assert (language != 1)
+    assert (language == language)
+
+def test_key():
+    key = Key(email="test@example.org", apikey="1234abcd")
+    assert (key.__hash__() == hash('1234abcd'))
+    assert (key.__repr__() == f"<Key email=test@example.org apikey=1234abcd>")
+    assert (key != 1)
+    assert (key == key)
+    time = datetime.now()
+    key.last_updated = time
+    assert (key.serialize == {'apikey': '1234abcd',
+        'created_at': '',
+        'email': 'test@example.org',
+        'last_updated': time.strftime("%Y-%m-%d %H:%M:%S")
+    })

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -53,6 +53,11 @@ def test_get_single_resource(module_client, module_db):
     assert (resource.get('id') == 5)
 
 
+def test_get_favicon(module_client):
+    response = module_client.get("favicon.ico")
+    assert (response.status_code == 200)
+
+
 def test_paginator(module_client, module_db):
     client = module_client
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -3,6 +3,7 @@ from tests import conftest
 from app.models import Resource, Language, Category
 from configs import PaginatorConfig
 from app.cli import import_resources
+from datetime import datetime, timedelta
 
 
 ##########################################
@@ -32,6 +33,19 @@ def test_get_resources(module_client, module_db):
         assert (isinstance(resource.get('category'), str))
         assert (resource.get('category'))
         assert (isinstance(resource.get('languages'), list))
+
+    ua = datetime.now() + timedelta(days=-7)
+    uaString = ua.strftime('%m-%d-%Y')
+    response = client.get(f"/api/v1/resources?updated_after={uaString}")
+    assert (response.status_code == 200)
+
+    # If updated_after date is after today, then should return a 422
+    ua = datetime.now() + timedelta(days=1)
+    uaString = ua.strftime('%m-%d-%Y')
+    response = client.get(f"/api/v1/resources?updated_after={uaString}")
+    assert (response.status_code == 422)
+    assert (response.json.get('errors')[0].get('code') == "unprocessable-entity")
+    assert ("updated_after" in response.json.get('errors')[0].get('message'))
 
 
 def test_get_single_resource(module_client, module_db):

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -181,6 +181,10 @@ def test_create_resource(module_client, module_db, fake_auth_from_oc):
     assert (isinstance(response.json['data'].get('id'), int))
     assert (response.json['data'].get('name') == "Some Name")
 
+    response = create_resource(client, "invalidapikey")
+
+    assert (response.status_code == 401)
+
 
 def test_update_resource(module_client, module_db, fake_auth_from_oc):
     client = module_client

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -39,13 +39,16 @@ def test_get_resources(module_client, module_db):
     response = client.get(f"/api/v1/resources?updated_after={uaString}")
     assert (response.status_code == 200)
 
+
+def test_get_resources_post_date_failure(module_client):
+    client = module_client
     # If updated_after date is after today, then should return a 422
     ua = datetime.now() + timedelta(days=1)
     uaString = ua.strftime('%m-%d-%Y')
     response = client.get(f"/api/v1/resources?updated_after={uaString}")
     assert (response.status_code == 422)
     assert (response.json.get('errors')[0].get('code') == "unprocessable-entity")
-    assert ("updated_after" in response.json.get('errors')[0].get('message'))
+    assert (isinstance(response.json.get('errors')[0].get('message'), str))
 
 
 def test_get_single_resource(module_client, module_db):

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -9,6 +9,7 @@ from app.cli import import_resources
 ## Test Routes
 ##########################################
 
+
 # TODO: We need negative unit tests (what happens when bad data is sent)
 def test_get_resources(module_client, module_db):
     client = module_client
@@ -169,6 +170,17 @@ def test_update_votes(module_client, module_db):
 ##########################################
 
 
+def test_apikey_commit_error(module_client, module_db, fake_auth_from_oc, fake_commit_error):
+    client = module_client
+
+    response = client.post('api/v1/apikey', json = dict(
+        email="test@example.org",
+        password="supersecurepassword"
+    ))
+
+    assert (response.status_code == 500)
+
+
 def test_get_api_key(module_client, module_db, fake_auth_from_oc):
     client = module_client
 
@@ -182,32 +194,100 @@ def test_get_api_key(module_client, module_db, fake_auth_from_oc):
     assert (isinstance(response.json['data'].get('apikey'), str))
 
 
+def test_get_api_key(module_client, module_db, fake_invalid_auth_from_oc):
+    client = module_client
+
+    response = client.post('api/v1/apikey',
+        follow_redirects=True,
+        json = dict(
+            email="test@example.org",
+            password="invalidpassword"
+    ))
+
+    assert (response.status_code == 401)
+
+
 def test_create_resource(module_client, module_db, fake_auth_from_oc):
     client = module_client
 
+    # Happy Path
     apikey = get_api_key(client)
     response = create_resource(client, apikey)
     assert (response.status_code == 200)
     assert (isinstance(response.json['data'].get('id'), int))
     assert (response.json['data'].get('name') == "Some Name")
 
+    # Invalid API Key Path
     response = create_resource(client, "invalidapikey")
-
     assert (response.status_code == 401)
 
 
 def test_update_resource(module_client, module_db, fake_auth_from_oc):
     client = module_client
 
+    # Happy Path
+    apikey = get_api_key(client)
+
+    response = client.put("/api/v1/resources/1",
+        json = dict(
+            name="New name",
+            languages=["New language"],
+            category="New Category",
+            url="https://new.url",
+            paid=False,
+            notes="New notes"
+        ),
+        headers = {'x-apikey': apikey}
+    )
+
+    assert (response.status_code == 200)
+    assert (response.json['data'].get('name') == "New name")
+
+    # Resource not found
+    response = client.put("/api/v1/resources/0",
+        json = dict(name="New name"),
+        headers = {'x-apikey': apikey},
+        follow_redirects = True
+    )
+    assert (response.status_code == 404)
+
+
+def test_commit_errors(module_client, module_db, fake_auth_from_oc, fake_commit_error):
+    client = module_client
     apikey = get_api_key(client)
 
     response = client.put("/api/v1/resources/1",
         json = dict(name="New name"),
         headers = {'x-apikey': apikey}
     )
+    assert (response.status_code == 500)
 
-    assert (response.status_code == 200)
-    assert (response.json['data'].get('name') == "New name")
+    response = create_resource(client, apikey)
+    assert (response.status_code == 500)
+
+
+def test_key_query_error(module_client, module_db, fake_auth_from_oc, fake_key_query_error):
+    client = module_client
+    response = client.post('api/v1/apikey', json = dict(
+        email="test@example.org",
+        password="supersecurepassword"
+    ))
+    assert (response.status_code == 500)
+
+def test_internal_server_error_handler(module_client, module_db, fake_items_error):
+    client = module_client
+
+    response = client.get('api/v1/resources')
+    assert (response.status_code == 500)
+    assert (response.json['errors'][0].get("code") == "server-error")
+
+    response = client.get('api/v1/languages')
+    assert (response.status_code == 500)
+    assert (response.json['errors'][0].get("code") == "server-error")
+
+    response = client.get('api/v1/categories')
+    assert (response.status_code == 500)
+    assert (response.json['errors'][0].get("code") == "server-error")
 
 
 ##########################################

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -141,6 +141,11 @@ def test_update_votes(module_client, module_db):
     assert (response.status_code == 200)
     assert (response.json['data'].get(f"{vote_direction}s") == initial_votes + 1)
 
+    vote_direction = 'downvote'
+    response = client.put(f"/api/v1/resources/{id}/{vote_direction}", follow_redirects=True)
+    assert (response.status_code == 200)
+    assert (response.json['data'].get(f"{vote_direction}s") == initial_votes + 1)
+
     # Check voting on an invalid resource
     id = 'waffles'
     response = client.put(f"/api/v1/resources/{id}/{vote_direction}", follow_redirects=True)


### PR DESCRIPTION
There is no test coverage asserting the JSON returned from a 500 error, so I wanted to go ahead and add that. Current implementation fails the tests rather than allowing the API to return a 500. Hopefully we can figure out how to "raise an error" without letting it bubble all the way up to the test suite.

I went ahead and tried to increase test coverage in all the ways I know how. It's now up to 88%. Suggestions about how exactly to increase test coverage in the remaining 12% would be appreciated, but I'm not sure how to test the CLI or the error handlers (as a matter of fact, I'm not entirely convinced the handlers even work, so any thoughts surrounding that are appreciated).