### PR TITLE
Disable strict slashes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ API_VERSION = "1.0"
 def create_app(config_class=Config):
     app = Flask(__name__, static_folder=None)
     app.config.from_object(config_class)
+    app.url_map.strict_slashes = False
 
     Limiter(
         app,


### PR DESCRIPTION
I've gotten caught up by this so many times that I'm rather annoyed by it. I fully understand the reasons for having strict slashes, but I think that from a usability perspective, I'd rather the API not return a 404 just because someone put in a slash at the end.