### PR TITLE
Add basic validation to create resource endpoint

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -25,6 +25,9 @@ def resources():
 @bp.route('/resources', methods=['POST'], endpoint='create_resource')
 @authenticate
 def post_resources():
+    validation_errors = validate_resource(request.get_json())
+    if validation_errors:
+        return standardize_response(payload=validation_errors, status_code=422)
     return create_resource(request.get_json(), db)
 
 
@@ -355,3 +358,27 @@ def create_new_apikey(email):
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
+
+
+def validate_resource(json):
+    validation_errors = {'errors': {'type': 'validation'}}
+    if not json:
+        message = "A JSON body is required to use this endpoint, but none was given"
+        validation_errors['errors']['message'] = message
+        return validation_errors
+
+    validation_errors['errors']['missing_params'] = []
+
+    required = []
+    for column in Resource.__table__.columns:
+        if column.nullable is False and column.name != 'id':
+            # strip _id from category_id
+            name = column.name.replace('_id', '')
+            required.append(name)
+
+    for prop in required:
+        if not json.get(prop):
+            validation_errors['errors']['missing_params'].append(prop)
+
+    if validation_errors['errors']['missing_params']:
+        return validation_errors

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -291,6 +291,17 @@ def test_create_resource(module_client, module_db, fake_auth_from_oc):
     response = create_resource(client, "invalidapikey")
     assert (response.status_code == 401)
 
+    # Invalid Resource Path
+    response = client.post('/api/v1/resources',
+        headers = {'x-apikey': apikey}
+    )
+    assert (response.status_code == 422)
+    response = client.post('/api/v1/resources',
+        json = dict(notes="Missing Required fields"),
+        headers = {'x-apikey': apikey}
+    )
+    assert (response.status_code == 422)
+
 
 def test_update_resource(module_client, module_db, fake_auth_from_oc):
     client = module_client
@@ -406,6 +417,8 @@ def test_rate_limit(module_client, module_db):
 ##########################################
 ## Helpers
 ##########################################
+
+
 def create_resource(client, apikey):
     return client.post('/api/v1/resources',
         json = dict(


### PR DESCRIPTION
Fixes #113 

Now, if you're missing a required parameter (currently, `name`, `url`, and `category`), you will get a response similar to the following:
```json
{
    "apiVersion": "1.0",
    "data": null,
    "errors": {
        "missing_params": [
            "name",
            "url",
            "category"
        ],
        "type": "validation"
    },
    "status": "Unprocessable Entity",
    "status_code": 422
}
```