### PR TITLE
Feature/add pagination details

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -170,12 +170,12 @@ def get_resources():
         resource_list = [
             resource.serialize for resource in paginated_resources.items
         ]
+        pagination_details = resource_paginator.pagination_details(paginated_resources)
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=resource_list),
-                                paginated_data=paginated_resources)
+    return standardize_response(payload=dict(data=resource_list, **pagination_details))
 
 
 def get_languages():
@@ -187,12 +187,12 @@ def get_languages():
         language_list = [
             language.serialize for language in paginated_languages.items
         ]
+        pagination_details = language_paginator.pagination_details(paginated_languages)
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=language_list),
-                                paginated_data=paginated_languages)
+    return standardize_response(payload=dict(data=language_list, **pagination_details))
 
 
 def get_categories():
@@ -204,13 +204,12 @@ def get_categories():
         category_list = [
             category.serialize for category in paginated_categories.items
         ]
-
+        pagination_details = category_paginator.pagination_details(paginated_categories)
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=category_list),
-                                paginated_data=paginated_categories)
+    return standardize_response(payload=dict(data=category_list, **pagination_details))
 
 
 def get_attributes(json):

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -174,7 +174,8 @@ def get_resources():
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=resource_list), paginated_data=paginated_resources)
+    return standardize_response(payload=dict(data=resource_list),
+                                paginated_data=paginated_resources)
 
 
 def get_languages():
@@ -190,7 +191,8 @@ def get_languages():
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=language_list), paginated_data=paginated_languages)
+    return standardize_response(payload=dict(data=language_list),
+                                paginated_data=paginated_languages)
 
 
 def get_categories():
@@ -207,7 +209,8 @@ def get_categories():
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=category_list), paginated_data=paginated_categories)
+    return standardize_response(payload=dict(data=category_list),
+                                paginated_data=paginated_categories)
 
 
 def get_attributes(json):

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -167,6 +167,8 @@ def get_resources():
 
     try:
         paginated_resources = resource_paginator.paginated_data(q)
+        if not paginated_resources:
+            return redirect('/404')
         resource_list = [
             resource.serialize for resource in paginated_resources.items
         ]
@@ -184,6 +186,8 @@ def get_languages():
 
     try:
         paginated_languages = language_paginator.paginated_data(query)
+        if not paginated_languages:
+            return redirect('/404')
         language_list = [
             language.serialize for language in paginated_languages.items
         ]
@@ -201,6 +205,8 @@ def get_categories():
         query = Category.query
 
         paginated_categories = category_paginator.paginated_data(query)
+        if not paginated_categories:
+            return redirect('/404')
         category_list = [
             category.serialize for category in paginated_categories.items
         ]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -166,14 +166,15 @@ def get_resources():
         )
 
     try:
+        paginated_resources = resource_paginator.paginated_data(q)
         resource_list = [
-            resource.serialize for resource in resource_paginator.items(q)
+            resource.serialize for resource in paginated_resources.items
         ]
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=resource_list))
+    return standardize_response(payload=dict(data=resource_list), paginated_data=paginated_resources)
 
 
 def get_languages():
@@ -181,14 +182,15 @@ def get_languages():
     query = Language.query
 
     try:
+        paginated_languages = language_paginator.paginated_data(query)
         language_list = [
-            language.serialize for language in language_paginator.items(query)
+            language.serialize for language in paginated_languages.items
         ]
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=language_list))
+    return standardize_response(payload=dict(data=language_list), paginated_data=paginated_languages)
 
 
 def get_categories():
@@ -196,15 +198,16 @@ def get_categories():
         category_paginator = Paginator(Config.CATEGORY_PAGINATOR, request)
         query = Category.query
 
+        paginated_categories = category_paginator.paginated_data(query)
         category_list = [
-            category.serialize for category in category_paginator.items(query)
+            category.serialize for category in paginated_categories.items
         ]
 
     except Exception as e:
         logger.exception(e)
         return standardize_response(status_code=500)
 
-    return standardize_response(payload=dict(data=category_list))
+    return standardize_response(payload=dict(data=category_list), paginated_data=paginated_categories)
 
 
 def get_attributes(json):

--- a/app/utils.py
+++ b/app/utils.py
@@ -14,11 +14,13 @@ class Paginator:
         if self.page_size > configuration.max_page_size:
             self.page_size = configuration.max_page_size
 
-    def items(self, query):
-        return query.paginate(self.page, self.page_size, False).items
 
+    def paginated_data(self, query):
+        data = query.paginate(self.page, self.page_size, False)
+        setattr(data, "per_page", self.configuration.per_page)
+        return data
 
-def standardize_response(payload=None, status_code=200):
+def standardize_response(payload=None, status_code=200, paginated_data=None):
     """Response helper
     This simplifies the response creation process by providing an internally
     defined mapping of status codes to messages for errors. It also knows when
@@ -71,6 +73,11 @@ def standardize_response(payload=None, status_code=200):
         resp["status"] = "error"
     else:
         resp["data"] = data
+
+    if paginated_data:
+        resp["page"] = paginated_data.page
+        resp["number_of_pages"] = paginated_data.pages
+        resp["records_per_page"] = paginated_data.per_page
 
     return jsonify(resp), resp["status_code"], {'Content-Type': 'application/json'}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,8 +19,17 @@ class Paginator:
         setattr(data, "per_page", self.configuration.per_page)
         return data
 
+    def pagination_details(self, paginated_data):
+        return {
+            "pagination_details": {
+                "page": paginated_data.page,
+                "number_of_pages": paginated_data.pages,
+                "records_per_page": paginated_data.per_page
+            }
+        }
 
-def standardize_response(payload=None, status_code=200, paginated_data=None):
+
+def standardize_response(payload={}, status_code=200):
     """Response helper
     This simplifies the response creation process by providing an internally
     defined mapping of status codes to messages for errors. It also knows when
@@ -34,10 +43,9 @@ def standardize_response(payload=None, status_code=200, paginated_data=None):
     status_code -- a valid HTTP status code. For errors it defaults to 500,
     for 'ok' it defaults to 200
     """
-    if not payload:
-        payload = {}
     data = payload.get("data")
     errors = payload.get("errors")
+    pagination_details = payload.get("pagination_details")
     resp = dict(
         apiVersion=API_VERSION,
         status="ok",
@@ -74,10 +82,8 @@ def standardize_response(payload=None, status_code=200, paginated_data=None):
     else:
         resp["data"] = data
 
-    if paginated_data:
-        resp["page"] = paginated_data.page
-        resp["number_of_pages"] = paginated_data.pages
-        resp["records_per_page"] = paginated_data.per_page
+    if pagination_details:
+        resp.update(pagination_details)
 
     return jsonify(resp), resp["status_code"], {'Content-Type': 'application/json'}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,7 +19,7 @@ class Paginator:
         if self.page > data.pages:
             return None
 
-        setattr(data, "per_page", self.configuration.per_page)
+        setattr(data, "per_page", self.page_size)
         return data
 
     def pagination_details(self, paginated_data):

--- a/app/utils.py
+++ b/app/utils.py
@@ -14,11 +14,11 @@ class Paginator:
         if self.page_size > configuration.max_page_size:
             self.page_size = configuration.max_page_size
 
-
     def paginated_data(self, query):
         data = query.paginate(self.page, self.page_size, False)
         setattr(data, "per_page", self.configuration.per_page)
         return data
+
 
 def standardize_response(payload=None, status_code=200, paginated_data=None):
     """Response helper

--- a/app/utils.py
+++ b/app/utils.py
@@ -24,7 +24,10 @@ class Paginator:
             "pagination_details": {
                 "page": paginated_data.page,
                 "number_of_pages": paginated_data.pages,
-                "records_per_page": paginated_data.per_page
+                "records_per_page": paginated_data.per_page,
+                "total_count": paginated_data.total,
+                "has_next": paginated_data.has_next,
+                "has_prev": paginated_data.has_prev
             }
         }
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -16,6 +16,9 @@ class Paginator:
 
     def paginated_data(self, query):
         data = query.paginate(self.page, self.page_size, False)
+        if self.page > data.pages:
+            return None
+
         setattr(data, "per_page", self.configuration.per_page)
         return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,14 +135,14 @@ def fake_invalid_auth_from_oc(mocker):
     mocker.patch("requests.post", return_value=FakeExternalResponse())
 
 @pytest.fixture(scope='function')
-def fake_items_error(mocker):
+def fake_paginated_data_error(mocker):
     """
     Mocks an exception being raised during pagination to test error handling
     """
-    def items():
+    def paginated_data():
         raise Exception("An \"unexpected\" Exception was raised!")
 
-    mocker.patch('app.utils.Paginator.items', side_effect=items)
+    mocker.patch('app.utils.Paginator.paginated_data', side_effect=paginated_data)
 
 @pytest.fixture(scope='function')
 def fake_commit_error(mocker):

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -33,20 +33,12 @@ def test_get_resources(module_client, module_db):
         assert (isinstance(resource.get('category'), str))
         assert (resource.get('category'))
         assert (isinstance(resource.get('languages'), list))
+    assert (resources['number_of_pages'] is not None)
 
     ua = datetime.now() + timedelta(days=-7)
     uaString = ua.strftime('%m-%d-%Y')
     response = client.get(f"/api/v1/resources?updated_after={uaString}")
     assert (response.status_code == 200)
-
-    # Test pagination details are included
-    response = client.get('api/v1/resources').json
-    assert (response['number_of_pages'] is not None)
-    assert (response['records_per_page'] == PaginatorConfig.per_page)
-    assert (response['page'] == 1)
-    assert (response['total_count'] is not None)
-    assert (response['has_next'] is not None)
-    assert (response['has_prev'] is not None)
 
     # Test trying to get a page of results that doesn't exist
     too_far = 99999999
@@ -118,6 +110,17 @@ def test_paginator(module_client, module_db):
     too_long = PaginatorConfig.max_page_size + 1
     response = client.get(f"api/v1/resources?page_size={too_long}")
     assert (len(response.json['data']) == PaginatorConfig.max_page_size)
+    assert (response.json['records_per_page'] == PaginatorConfig.max_page_size)
+
+    # Test pagination details are included
+    page_size = 51
+    response = client.get(f"api/v1/resources?page_size={page_size}").json
+    assert (response['number_of_pages'] is not None)
+    assert (response['records_per_page'] == page_size)
+    assert (response['page'] == 1)
+    assert (response['total_count'] is not None)
+    assert (response['has_next'] is not None)
+    assert (response['has_prev'] is not None)
 
 
 def test_filters(module_client, module_db):
@@ -149,11 +152,6 @@ def test_languages(module_client, module_db):
         assert (isinstance(language.get('name'), str))
         assert (language.get('name'))
     assert (response.json['number_of_pages'] is not None)
-    assert (response.json['records_per_page'] == PaginatorConfig.per_page)
-    assert (response.json['page'] == 1)
-    assert (response.json['total_count'] is not None)
-    assert (response.json['has_next'] is not None)
-    assert (response.json['has_prev'] is not None)
 
     # Test trying to get a page of results that doesn't exist
     too_far = 99999999
@@ -172,11 +170,7 @@ def test_categories(module_client, module_db):
         assert (isinstance(category.get('name'), str))
         assert (category.get('name'))
     assert (response.json['number_of_pages'] is not None)
-    assert (response.json['records_per_page'] == PaginatorConfig.per_page)
-    assert (response.json['page'] == 1)
-    assert (response.json['total_count'] is not None)
-    assert (response.json['has_next'] is not None)
-    assert (response.json['has_prev'] is not None)
+
 
     # Test trying to get a page of results that doesn't exist
     too_far = 99999999

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -114,6 +114,9 @@ def test_paginator(module_client, module_db):
     assert (response['number_of_pages'] is not None)
     assert (response['records_per_page'] == PaginatorConfig.per_page)
     assert (response['page'] == 1)
+    assert (response['total_count'] is not None)
+    assert (response['has_next'] is not None)
+    assert (response['has_prev'] is not None)
 
 def test_filters(module_client, module_db):
     client = module_client

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -143,6 +143,9 @@ def test_languages(module_client, module_db):
         assert (isinstance(language.get('id'), int))
         assert (isinstance(language.get('name'), str))
         assert (language.get('name'))
+    assert (response.json['number_of_pages'] is not None)
+    assert (response.json['records_per_page'] == PaginatorConfig.per_page)
+    assert (response.json['page'] == 1)
 
 
 def test_categories(module_client, module_db):
@@ -154,6 +157,9 @@ def test_categories(module_client, module_db):
         assert (isinstance(category.get('id'), int))
         assert (isinstance(category.get('name'), str))
         assert (category.get('name'))
+    assert (response.json['number_of_pages'] is not None)
+    assert (response.json['records_per_page'] == PaginatorConfig.per_page)
+    assert (response.json['page'] == 1)
 
 
 def test_update_votes(module_client, module_db):

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -109,6 +109,11 @@ def test_paginator(module_client, module_db):
     response = client.get(f"api/v1/resources?page_size=100&page={too_far}")
     assert (not response.json['data'])
 
+    # Test pagination details are included
+    response = client.get('api/v1/resources').json
+    assert (response['number_of_pages'] is not None)
+    assert (response['records_per_page'] == PaginatorConfig.per_page)
+    assert (response['page'] == 1)
 
 def test_filters(module_client, module_db):
     client = module_client
@@ -340,7 +345,7 @@ def test_key_query_error(module_client, module_db, fake_auth_from_oc, fake_key_q
     ))
     assert (response.status_code == 500)
 
-def test_internal_server_error_handler(module_client, module_db, fake_items_error):
+def test_internal_server_error_handler(module_client, module_db, fake_paginated_data_error):
     client = module_client
 
     response = client.get('api/v1/resources')

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -39,6 +39,21 @@ def test_get_resources(module_client, module_db):
     response = client.get(f"/api/v1/resources?updated_after={uaString}")
     assert (response.status_code == 200)
 
+    # Test pagination details are included
+    response = client.get('api/v1/resources').json
+    assert (response['number_of_pages'] is not None)
+    assert (response['records_per_page'] == PaginatorConfig.per_page)
+    assert (response['page'] == 1)
+    assert (response['total_count'] is not None)
+    assert (response['has_next'] is not None)
+    assert (response['has_prev'] is not None)
+
+    # Test trying to get a page of results that doesn't exist
+    too_far = 99999999
+    response = client.get(f"api/v1/resources?page_size=100&page={too_far}", follow_redirects=True)
+    assert (response.status_code == 404)
+    assert (response.json.get('errors')[0].get('code') == "not-found")
+
 
 def test_get_resources_post_date_failure(module_client):
     client = module_client
@@ -104,19 +119,6 @@ def test_paginator(module_client, module_db):
     response = client.get(f"api/v1/resources?page_size={too_long}")
     assert (len(response.json['data']) == PaginatorConfig.max_page_size)
 
-    # Test farther than last page
-    too_far = 99999999
-    response = client.get(f"api/v1/resources?page_size=100&page={too_far}")
-    assert (not response.json['data'])
-
-    # Test pagination details are included
-    response = client.get('api/v1/resources').json
-    assert (response['number_of_pages'] is not None)
-    assert (response['records_per_page'] == PaginatorConfig.per_page)
-    assert (response['page'] == 1)
-    assert (response['total_count'] is not None)
-    assert (response['has_next'] is not None)
-    assert (response['has_prev'] is not None)
 
 def test_filters(module_client, module_db):
     client = module_client
@@ -149,6 +151,15 @@ def test_languages(module_client, module_db):
     assert (response.json['number_of_pages'] is not None)
     assert (response.json['records_per_page'] == PaginatorConfig.per_page)
     assert (response.json['page'] == 1)
+    assert (response.json['total_count'] is not None)
+    assert (response.json['has_next'] is not None)
+    assert (response.json['has_prev'] is not None)
+
+    # Test trying to get a page of results that doesn't exist
+    too_far = 99999999
+    response = client.get(f"api/v1/languages?page_size=100&page={too_far}", follow_redirects=True)
+    assert (response.status_code == 404)
+    assert (response.json.get('errors')[0].get('code') == "not-found")
 
 
 def test_categories(module_client, module_db):
@@ -163,6 +174,15 @@ def test_categories(module_client, module_db):
     assert (response.json['number_of_pages'] is not None)
     assert (response.json['records_per_page'] == PaginatorConfig.per_page)
     assert (response.json['page'] == 1)
+    assert (response.json['total_count'] is not None)
+    assert (response.json['has_next'] is not None)
+    assert (response.json['has_prev'] is not None)
+
+    # Test trying to get a page of results that doesn't exist
+    too_far = 99999999
+    response = client.get(f"api/v1/categories?page_size=100&page={too_far}", follow_redirects=True)
+    assert (response.status_code == 404)
+    assert (response.json.get('errors')[0].get('code') == "not-found")
 
 
 def test_update_votes(module_client, module_db):


### PR DESCRIPTION
This feature adds the following json blob any paginated response:
```
"page": <page_number>,
"number_of_pages": <total_number_of_pages>,
"records_per_page": <records_per_page>,
```
To implement this, I decided to change `items()` in `Paginator` to return the full paginated data object and renamed it `paginated_data()` because to get the pagination details we need the object returned from `query.paginate` (already called in `items()`) and I didn't want to make two calls. To get items, we now do `paginated_data().items`

I then added the pagination details in the `standardize_response` method when paginated_data is present (so only for paginated responses). I also updated the controller actions that use pagination to be compatible with my changes.

Finally, I ensured pagination details were getting returned in the test`test_paginator`. Because of the change to `items()` I also had to update `fake_items_error(mocker)` in `conftest.py` to be `paginated_data_error(mocker)`.
