### PR TITLE
Issue #126: remove MultipleResultsFound condition check from routes

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -2,7 +2,7 @@ from traceback import print_tb
 
 from flask import request, redirect
 from sqlalchemy import or_, func
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.api import bp
 from app.api.auth import is_user_oc_member, authenticate
@@ -94,10 +94,6 @@ def get_resource(id):
     resource = None
     try:
         resource = Resource.query.get(id)
-
-    except MultipleResultsFound as e:
-        print_tb(e.__traceback__)
-        logger.exception(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)
@@ -229,10 +225,6 @@ def update_votes(id, vote_direction):
 
         if not resource:
             return redirect('/404')
-
-    except MultipleResultsFound as e:
-        print_tb(e.__traceback__)
-        logger.exception(e)
 
     except NoResultFound as e:
         print_tb(e.__traceback__)


### PR DESCRIPTION
Issue #126: remove MultipleResultsFound condition check from routes.

Getting multiple results from resources is impossible is because results are queried by `id` and `id` is a unique identifier. Therefore, the check for `MultipleResultsFound` is not necessary.

see https://github.com/OperationCode/resources_api/pull/125#discussion_r272812093 for more details