### PR TITLE
Remove MultipleResultsFound that was somehow left in there

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -255,10 +255,6 @@ def add_click(id):
         if not resource:
             return redirect('/404')
 
-    except MultipleResultsFound as e:
-        print_tb(e.__traceback__)
-        logger.exception(e)
-
     except NoResultFound as e:
         print_tb(e.__traceback__)
         logger.exception(e)


### PR DESCRIPTION
This removes a lingering `MultipleResultsFound` that was supposed to have been removed in #127 