### PR TITLE
Fix the redirect when resource is not found

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -108,7 +108,7 @@ def get_resource(id):
     if resource:
         return standardize_response(payload=dict(data=(resource.serialize)))
 
-    redirect('/404')
+    return redirect('/404')
 
 
 def get_resources():

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -78,6 +78,20 @@ def test_get_single_resource(module_client, module_db):
     assert (resource.get('id') == 5)
 
 
+def test_single_resource_out_of_bounds(module_client, module_db):
+    client = module_client
+
+    too_low = 0
+    too_high = 9999
+    response = client.get(f"api/v1/resources{too_low}")
+
+    assert (response.status_code == 404)
+
+    response = client.get(f"api/v1/resources{too_high}")
+
+    assert (response.status_code == 404)
+
+
 def test_get_favicon(module_client):
     response = module_client.get("favicon.ico")
     assert (response.status_code == 200)


### PR DESCRIPTION
I was getting a 500 error when I would do `GET http://127.0.0.1:8000/api/v1/resources/9999`. This fixed that to make it a 404 instead.