### PR TITLE
Add filter for paid/free resources

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -126,6 +126,7 @@ def get_resources():
     language = request.args.get('language')
     category = request.args.get('category')
     updated_after = request.args.get('updated_after')
+    paid = request.args.get('paid')
 
     q = Resource.query
 
@@ -164,6 +165,11 @@ def get_resources():
                 Resource.last_updated >= uaDate
             )
         )
+
+    # Filter on paid
+    if isinstance(paid, str):
+        paidAsBool = paid.lower() == 'true'
+        q = q.filter(Resource.paid == paidAsBool)
 
     try:
         paginated_resources = resource_paginator.paginated_data(q)

--- a/app/models.py
+++ b/app/models.py
@@ -30,7 +30,7 @@ class Resource(TimestampMixin, db.Model):
                             nullable=False)
     category = db.relationship('Category')
     languages = db.relationship('Language', secondary=language_identifier)
-    paid = db.Column(db.Boolean, default=False)
+    paid = db.Column(db.Boolean, nullable=False, default=False)
     notes = db.Column(db.String)
     upvotes = db.Column(db.INTEGER, default=0)
     downvotes = db.Column(db.INTEGER, default=0)

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -137,6 +137,30 @@ def test_paginator(module_client, module_db):
     assert (response['has_prev'] is not None)
 
 
+def test_paid_filter(module_client, module_db):
+    client = module_client
+
+    total_resources = client.get('api/v1/resources').json['total_count']
+
+    # Filter by paid
+    response = client.get('api/v1/resources?paid=false')
+
+    total_free_resources = response.json['total_count']
+
+    assert all([res.get('paid') == False for res in response.json['data']])
+
+    response = client.get('api/v1/resources?paid=true')
+
+    total_paid_resources = response.json['total_count']
+
+    assert all([res.get('paid') == True for res in response.json['data']])
+
+    # Check that the number of resources appear correct
+    assert (total_paid_resources > 0)
+    assert (total_free_resources > 0)
+    assert (total_resources == total_free_resources + total_paid_resources)
+
+
 def test_filters(module_client, module_db):
     client = module_client
 


### PR DESCRIPTION
Fixes #130 

This filter works for me locally, but for some reason when the query occurs in the tests it returns no resources and then the response redirects to `404` (which would be correct if there were no resources). I'm confused why this is happening since I'm pretty sure it's the same seed data in `module_db` as in my local db. Help fixing the test would be greatly appreciated!