### PR TITLE
Fix bug when creating a Free resource

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -383,7 +383,7 @@ def validate_resource(json):
             required.append(name)
 
     for prop in required:
-        if not json.get(prop):
+        if json.get(prop) is None:
             validation_errors['errors']['missing_params'].append(prop)
 
     if validation_errors['errors']['missing_params']:


### PR DESCRIPTION
When creating a free resource, `paid` is `False`. This means that you would always get a validation error. This change checks for `None` explicitly, allowing values of `False` to still be considered valid (as they should be).