### PR TITLE
Use port 5000 instead of 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN pip install -r requirements.txt
 
 COPY . /src
 
-EXPOSE 8000
+EXPOSE 5000
 
-CMD ["python", "run.py"]
+CMD ["flask", "run", "-h", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ fresh-restart: minty-fresh test setup run
 
 .PHONY: run
 run: build
-	${DOCKER_COMPOSE} run -p 8000:8000 ${RESOURCES_CONTAINER} ${FLASK} run -p 8000 -h 0.0.0.0
+	${DOCKER_COMPOSE} run -p 5000:5000 ${RESOURCES_CONTAINER} ${FLASK} run -h 0.0.0.0
 
 .PHONY: bg
 bg:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sometimes these installs can be tricky.  If you get stuck ask for help in the Sl
 - Linux: install [docker compose](https://docs.docker.com/compose/install/#install-compose) as well.
 4. [Install Make](http://gnuwin32.sourceforge.net/packages/make.htm) if you're on Windows. OSX already has it installed. Linux will tell you how to install it (i.e., `sudo apt-get install make`)
 5. Run `make setup`
-6. Run `make all` and then navigate to http://localhost:8000/api/v1/resources
+6. Run `make all` and then navigate to http://localhost:5000/api/v1/resources
 
 If you see some JSON with a bunch of resources, it worked! If you encounter any errors, please open an issue or contact us on slack in #oc-python-projects.
 
@@ -26,7 +26,7 @@ If you see some JSON with a bunch of resources, it worked! If you encounter any 
 
  Routes that modify the database (e.g., `POST` and `PUT`) are authenticated routes. You need to include a header in your request with your API key. To generate an API key:
 
- 1. Send a POST to http://localhost:8000/api/v1/apikey with the following JSON payload:
+ 1. Send a POST to http://localhost:5000/api/v1/apikey with the following JSON payload:
 ```json
 {
 	"email": "your@email.com",
@@ -51,7 +51,7 @@ The email and password specified should be your login credentials for the Operat
 Example curl request to an authenticated route:
 ```bash
 curl -X POST \
-  http://127.0.0.1:8000/api/v1/resources \
+  http://127.0.0.1:5000/api/v1/resources \
   -H 'Content-Type: application/json' \
   -H 'x-apikey: 0a14f702da134390ae43f3639686fe26' \
   -d '{

--- a/configs.py
+++ b/configs.py
@@ -36,7 +36,6 @@ if not postgres_host:
 class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = f"postgresql://{postgres_user}:{postgres_password}@{postgres_host}:5432/{postgres_db}"
-    print(SQLALCHEMY_DATABASE_URI)
 
     # Can pass in changes to defaults, such as PaginatorConfig(per_page=40)
     RESOURCE_PAGINATOR = PaginatorConfig()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
     - .:/src
     ports:
-    - 8000:8000
+    - 5000:5000
     links:
     - resources-postgres
     depends_on:


### PR DESCRIPTION
For some strange reason when we switched to Docker, we started using port 8000. I'm not really sure why that was the case, but now in prod we're using the default port when we run flask. I think it's a good idea for local environments to more closely resemble prod, so I made the change in the Dockerfile and elsewhere to use the default port.