### PR TITLE
Change POSTGRES_HOST to resources-postgres

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 POSTGRES_USER=user_name
 POSTGRES_PASSWORD=change_password
-POSTGRES_HOST=resources-psql
+POSTGRES_HOST=resources-postgres
 POSTGRES_DB=resources-psql
 FLASK_ENV=development
 FLASK_DEBUG=1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER := docker
 DOCKER_COMPOSE := docker-compose
 RESOURCES_CONTAINER := resources-api
-RESOURCES_DB := resources-psql
+RESOURCES_DB := resources-postgres
 FLASK := flask
 
 .PHONY: all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
     ports:
     - 8000:8000
     links:
-    - resources-psql
+    - resources-postgres
     depends_on:
-    - resources-psql
+    - resources-postgres
 
-  resources-psql:
+  resources-postgres:
     image: postgres:10.1-alpine
-    container_name: resources-psql
+    container_name: resources-postgres
     environment:
     - POSTGRES_USER=${POSTGRES_USER}
     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
This changes the name of the Postgres host to `resources-postgres` to more closely resemble production. See https://github.com/OperationCode/operationcode_infra for the prod configuration