### PR TITLE
Fix issues with the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ nuke:
 
 .PHONY: minty-fresh
 minty-fresh:
-	${DOCKER_COMPOSE} down --rmi all --volumes
+	${DOCKER_COMPOSE} down --rmi all --volumes --remove-orphans
 
 .PHONY: rmi
 rmi:
@@ -32,6 +32,7 @@ fresh-restart: minty-fresh test setup run
 
 .PHONY: run
 run: build
+	if [ "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} down; fi
 	${DOCKER_COMPOSE} run -p 5000:5000 ${RESOURCES_CONTAINER}
 
 .PHONY: bg


### PR DESCRIPTION
There are two issues with the Makefile that have been annoying me and @Digbigpig, so I fixed them.

1) Occasionally there are orphan containers when you try to do `make minty-fresh` and the command fails rather than successfully removing the orphan containers. This will make it truly minty-fresh.

2) After a recent change to the `CMD` in the Dockerfile, `make fresh-restart` fails because the container is already running. This takes down the container that's created by the Dockerfile CMD and brings it back up for you automagically.

This shouldn't negatively affect any situations where these problems are not present.