### PR TITLE
Add security checks

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
 - make build
 - make test
 - make lint
+- make bandit
 after_success:
 - bash bin/run.sh
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ test-coverage:
 lint:
 	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} flake8 app --statistics --count
 
+.PHONY: bandit
+bandit:
+	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} bandit -r .
+
 .PHONY: help
 help: build
 	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} --help

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-mock==1.10.1
 pyyaml==5.1
 requests==2.21.0
 SQLAlchemy-Utils==0.33.11
+bandit==1.5.1


### PR DESCRIPTION
Fixes #153 

This adds bandit into the CI pipeline. I went ahead and excluded `/tests` because there were a bunch of issues but I don't think that matters. Because I wanted to exclude `/tests`, I had to specify bandit 1.5.1. We will need to upgrade past 1.6.0 once this is resolved https://github.com/PyCQA/bandit/issues/488 or we won't be able to exclude the tests directory.