### PR TITLE
Log to stdout instead of log files

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -3,8 +3,8 @@ from flask import request
 from app.models import Key
 from app.utils import standardize_response, setup_logger
 
-create_logger = setup_logger('create_auth_logger', 'log/create_auth.log')
-update_logger = setup_logger('update_auth_logger', 'log/update_auth.log')
+create_logger = setup_logger('create_auth_logger')
+update_logger = setup_logger('update_auth_logger')
 
 
 def authenticate(func):

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -15,7 +15,7 @@ import uuid
 failures_counter = Counter('my_failures', 'Number of exceptions raised')
 latency_summary = Summary('request_latency_seconds', 'Length of request')
 
-logger = setup_logger('routes_logger', 'log/routes.log')
+logger = setup_logger('routes_logger')
 
 
 # Routes

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,6 +2,7 @@ from app import API_VERSION
 from flask import jsonify
 import logging
 import os
+import sys
 
 
 class Paginator:
@@ -94,13 +95,13 @@ def standardize_response(payload={}, status_code=200):
     return jsonify(resp), resp["status_code"], {'Content-Type': 'application/json'}
 
 
-def setup_logger(name, log_file, level=logging.INFO):
+def setup_logger(name, level=logging.INFO):
     """Function setup as many loggers as you want"""
     if not os.path.exists('log'):
         os.makedirs('log')  # pragma: no cover
 
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-    handler = logging.FileHandler(log_file)
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
 
     logger = logging.getLogger(name)


### PR DESCRIPTION
To facilitate ingesting of a single log stream, we should just log everything to stdout.