### PR TITLE
Fix linting errors in root directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-coverage:
 
 .PHONY: lint
 lint:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} flake8 app --statistics --count
+	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} flake8 . --exclude migrations,tests --statistics --count
 
 .PHONY: bandit
 bandit:

--- a/configs.py
+++ b/configs.py
@@ -16,26 +16,26 @@ def get_sys_exec_root_or_drive():
     return path
 
 
-postgres_user = os.environ.get('POSTGRES_USER')
-if not postgres_user:
+pg_user = os.environ.get('POSTGRES_USER')
+if not pg_user:
     raise KeyError("Application requires 'POSTGRES_USER' to run")
 
-postgres_password = os.environ.get('POSTGRES_PASSWORD')
-if not postgres_password:
+pg_pw = os.environ.get('POSTGRES_PASSWORD')
+if not pg_pw:
     raise KeyError("Application requires 'POSTGRES_PASSWORD' to run")
 
-postgres_db = os.environ.get('POSTGRES_DB')
-if not postgres_db:
+pg_db = os.environ.get('POSTGRES_DB')
+if not pg_db:
     raise KeyError("Application requires 'POSTGRES_DB' to run")
 
-postgres_host = os.environ.get('POSTGRES_HOST')
-if not postgres_host:
+pg_host = os.environ.get('POSTGRES_HOST')
+if not pg_host:
     raise KeyError("Application requires 'POSTGRES_HOST' to run")
 
 
 class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = f"postgresql://{postgres_user}:{postgres_password}@{postgres_host}:5432/{postgres_db}"
+    SQLALCHEMY_DATABASE_URI = f"postgresql://{pg_user}:{pg_pw}@{pg_host}:5432/{pg_db}"
 
     # Can pass in changes to defaults, such as PaginatorConfig(per_page=40)
     RESOURCE_PAGINATOR = PaginatorConfig()

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-from app import cli, create_app, db
+from app import cli, create_app
 from app.models import Category, Language, Resource, db
 from werkzeug.wsgi import DispatcherMiddleware
 from prometheus_client import make_wsgi_app


### PR DESCRIPTION
While looking into #99 I realized that there are some files such as `run.py` and `configs.py` that exist outside the `app` directory but are still critical to the application. These files were not being checked by `make lint`. Now they will be.

This fixes linting errors in those files, as well as changing the Makefile to include them in all future runs of `make lint`.