### PR TITLE
Fix auth to be compatible with new backend

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -22,10 +22,9 @@ def authenticate(func):
 
 
 def is_user_oc_member(email, password):
-    response = requests.post('https://api.operationcode.org/api/v1/sessions', json=dict(
-            user=dict(email=email,
-                      password=password
-                      )
+    response = requests.post('https://api.operationcode.org/auth/login/', json=dict(
+            email=email,
+            password=password
         )
     )
 


### PR DESCRIPTION
The new backend gets rid of the `user` dict and just sends the email and password directly. It's also to `/auth/login` rather than `api/v1/sessions`.