### PR TITLE
Bump SQLAlchemy-Utils to 0.34.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ pytest-mock==1.10.4
 pytest-cov==2.7.1
 pyyaml==5.1.1
 requests==2.22.0
-sqlalchemy==1.3.3
-SQLAlchemy-Utils==0.33.11
+SQLAlchemy-Utils==0.34.0
 prometheus_client==0.7.0
 uWSGI==2.0.18
 py-healthcheck==1.9.0


### PR DESCRIPTION
The 0.34.0 release fixes the reference to array_agg