### PR TITLE
Adding get_language route and tests

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -89,6 +89,13 @@ def languages():
 
 @latency_summary.time()
 @failures_counter.count_exceptions()
+@bp.route('/languages/<int:id>', methods=['GET'], endpoint='get_language')
+def language(id):
+    return get_language(id)
+
+
+@latency_summary.time()
+@failures_counter.count_exceptions()
 @bp.route('/categories', methods=['GET'])
 def categories():
     return get_categories()
@@ -263,6 +270,15 @@ def get_languages():
     return utils.standardize_response(payload=dict(
         data=language_list,
         **pagination_details))
+
+
+def get_language(id):
+    language = Language.query.get(id)
+
+    if language:
+        return utils.standardize_response(payload=dict(data=(language.serialize)))
+
+    return redirect('/404')
 
 
 def get_categories():

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -199,6 +199,35 @@ def test_languages(module_client, module_db):
     assert (response.json.get('errors')[0].get('code') == "not-found")
 
 
+def test_get_single_language(module_client, module_db):
+    client = module_client
+
+    response = client.get('api/v1/languages/3')
+
+    # Status should be OK
+    assert (response.status_code == 200)
+
+    language = response.json['data']
+    assert (isinstance(language.get('name'), str))
+    assert (language.get('name'))
+
+    assert (language.get('id') == 3)
+
+
+def test_single_language_out_of_bounds(module_client, module_db):
+    client = module_client
+
+    too_low = 0
+    too_high = 9999
+    response = client.get(f"api/v1/languages/{too_low}", follow_redirects=True)
+
+    assert (response.status_code == 404)
+
+    response = client.get(f"api/v1/languages/{too_high}", follow_redirects=True)
+
+    assert (response.status_code == 404)
+
+
 def test_categories(module_client, module_db):
     client = module_client
 


### PR DESCRIPTION
Followed same pattern as get_category route to set up the get_language route and added tests for getting a single language by ID and testing for out of bounds languages.
Tested retrieving a single language on Postman successfully.

