### PR TITLE
Add support for creating multiple resources to POST /resources endpoint

### DIFF
--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -321,7 +321,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Language_data'
               example:
-                apiVersion : '1.0'
+                apiVersion: '1.0'
                 data:
                   id: 2
                   name: 'Python'
@@ -567,20 +567,20 @@ paths:
                 status_code: 422
 
     post:
-      summary: Create Resource
-      description: Creates a new learning resource entry. The required properties for a new entry are `category`, `name`, `paid`, and `url` and must be included in the request body.
+      summary: Create Resources
+      description: Creates new learning resources. The structure of the request is a list of resource objects. The required properties for each new resource are `category`, `name`, `paid`, and `url`.
       tags:
-        - Create Resource
+        - Create Resources
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateResourceRequest'
+              $ref: '#/components/schemas/CreateResourcesRequest'
             example:
-              category: 'Tutorial'
-              name: 'CSS Tutorial'
-              paid: false
-              url: 'https://www.w3schools.com/css/'
+              - category: 'Tutorial'
+                name: 'CSS Tutorial'
+                paid: false
+                url: 'https://www.w3schools.com/css/'
         required: true
       responses:
         200:
@@ -588,23 +588,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Resource'
+                $ref: '#/components/schemas/Resource_list'
               example:
                 apiVersion: '1.0'
                 data:
-                  category: 'Tutorial'
-                  created_at: '2019-07-21 15:41:19'
-                  downvotes: 0
-                  id: 2137
-                  languages:
-                    - 'CSS'
-                  last_updated: '2019-07-22 16:05:53'
-                  name: 'CSS Tutorial'
-                  notes: null
-                  paid: false
-                  times_clicked: 3
-                  upvotes: 1
-                  url: 'https://www.w3schools.com/css/'
+                  - category: 'Tutorial'
+                    created_at: '2019-07-21 15:41:19'
+                    downvotes: 0
+                    id: 2137
+                    languages:
+                      - 'CSS'
+                    last_updated: '2019-07-22 16:05:53'
+                    name: 'CSS Tutorial'
+                    notes: null
+                    paid: false
+                    times_clicked: 3
+                    upvotes: 1
+                    url: 'https://www.w3schools.com/css/'
                 status: 'ok'
                 status_code: 200
         400:
@@ -616,22 +616,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error_list'
               example:
                   apiVersion: '1.0'
                   data: null
                   errors:
-                    invalid-params:
-                      - message: 'The following params were invalid: url. Resource id 2137 already has this URL.'
+                    - index: 0
+                      invalid-params:
+                        message: 'The following params were invalid: url. Resource id 2137 already has this URL.'
                         params:
                           - url
                         resource: 'https://resources.operationcode.org/api/v1/2137'
-                    missing-params:
-                        message: 'The following params were missing: name, category, paid.'
-                        params:
-                          - name
-                          - category
-                          - paid
+                      missing-params:
+                          message: 'The following params were missing: name, category, paid.'
+                          params:
+                            - name
+                            - category
+                            - paid
                   status: 'Unprocessable Entity'
                   status_code: 422
       security:
@@ -722,6 +723,93 @@ components:
             message:
               description: Error message
               type: string
+    Error_list:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+          description: API version
+        data:
+          type: object
+          description: A data object
+        errors:
+          $ref: '#/components/schemas/Error_list_data'
+        status:
+          type: string
+          description: Status message
+        status_code:
+          type: integer
+          description: Status code
+
+    Error_list_data:
+      type: array
+      items:
+        type: object
+        properties:
+          index:
+            type: integer
+            description: The index of the invalid resource
+          missing-params:
+            type: object
+            properties:
+              params:
+                description: The associated parameters.
+                type: array
+                items:
+                  type: string
+              message:
+                description: Error message
+                type: string
+          invalid-params:
+            type: object
+            properties:
+              params:
+                description: The associated parameters.
+                type: array
+                items:
+                  type: string
+              message:
+                description: Error message
+                type: string
+              resource:
+                description: An href link to the resource with a duplicate url
+                type: string
+          invalid-credentials:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
+          unauthorized:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
+          missing-body:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
+          unprocessable-entity:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
+          bad-request:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
+          not-found:
+            type: object
+            properties:
+              message:
+                description: Error message
+                type: string
 
 
     Resource:
@@ -825,11 +913,36 @@ components:
           description: Language Name
 
 
-    CreateResourceRequest:
+    CreateResourcesRequest:
       allOf:
-        - $ref: '#/components/schemas/ResourceRequest'
-        - required: [category, name, paid, url]
+        - $ref: '#/components/schemas/ResourcesRequest'
+        # - required: [category, name, paid, url]
 
+    ResourcesRequest:
+      type: array
+      items:
+        type: object
+        properties:
+          category:
+            type: string
+            description: Category
+          languages:
+            type: array
+            description: List of languages
+            items:
+              type: string
+          name:
+            type: string
+            description: Resource name
+          notes:
+            type: string
+            description: Resource notes
+          paid:
+            type: boolean
+            description: True or false for whether resource is paid
+          url:
+            type: string
+            description: Resource url
     ResourceRequest:
       type: object
       properties:
@@ -894,6 +1007,11 @@ components:
         url:
           type: string
           description: Resource url
+
+    Resource_list:
+      type: array
+      items:
+        $ref: '#/components/schemas/Resource_data'
 
     SearchResponse:
       type: object
@@ -1032,6 +1150,7 @@ components:
             {
               'apiVersion': '1.0',
               'data': null,
+              'error': 1,
               'errors': {
                 'invalid-credentials': {
                   'message': 'The email or password you submitted is incorrect'
@@ -1084,7 +1203,7 @@ components:
 tags:
   - name: List Resources
   - name: Get Resource
-  - name: Create Resource
+  - name: Create Resources
   - name: Update Resource
   - name: List Categories
   - name: Get Category
@@ -1103,7 +1222,7 @@ x-tagGroups:
     tags:
       - List Resources
       - Get Resource
-      - Create Resource
+      - Create Resources
       - Update Resource
   - name: Categories
     tags:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,6 +229,7 @@ def fake_algolia_unreachable_host(mocker):
 
     mocker.patch('algoliasearch.search_index.SearchIndex.search', side_effect=algolia_exception)
     mocker.patch('algoliasearch.search_index.SearchIndex.save_object', side_effect=algolia_exception)
+    mocker.patch('algoliasearch.search_index.SearchIndex.save_objects', side_effect=algolia_exception)
     mocker.patch('algoliasearch.search_index.SearchIndex.partial_update_object', side_effect=algolia_exception)
 
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -429,8 +429,8 @@ def test_create_resource(module_client, module_db, fake_auth_from_oc, fake_algol
     apikey = get_api_key(client)
     response = create_resource(client, apikey)
     assert (response.status_code == 200)
-    assert (isinstance(response.json['data'].get('id'), int))
-    assert (response.json['data'].get('name') == "Some Name")
+    assert (isinstance(response.json['data'][0].get('id'), int))
+    assert (response.json['data'][0].get('name') == "Some Name")
 
     # Invalid API Key Path
     response = create_resource(client, "invalidapikey")
@@ -495,19 +495,167 @@ def test_create_resource(module_client, module_db, fake_auth_from_oc, fake_algol
 
     # Missing Required Fields
     response = client.post('/api/v1/resources',
-                           json=dict(notes="Missing Required fields"),
+                           json=[dict(notes="Missing Required fields")],
                            headers={'x-apikey': apikey})
     assert (response.status_code == 422)
-    assert (isinstance(response.json.get('errors').get(MISSING_PARAMS), dict))
-    assert (isinstance(response.json.get('errors').get(MISSING_PARAMS).get('message'), str))
-    assert ("name" in response.json.get('errors').get(MISSING_PARAMS).get("params"))
-    assert ("name" in response.json.get('errors').get(MISSING_PARAMS).get("message"))
-    assert ("url" in response.json.get('errors').get(MISSING_PARAMS).get("params"))
-    assert ("url" in response.json.get('errors').get(MISSING_PARAMS).get("message"))
-    assert ("category" in response.json.get('errors').get(MISSING_PARAMS).get("params"))
-    assert ("category" in response.json.get('errors').get(MISSING_PARAMS).get("message"))
-    assert ("paid" in response.json.get('errors').get(MISSING_PARAMS).get("params"))
-    assert ("paid" in response.json.get('errors').get(MISSING_PARAMS).get("message"))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_PARAMS), dict))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_PARAMS).get('message'), str))
+    assert ("name" in response.json.get('errors')[0].get(MISSING_PARAMS).get("params"))
+    assert ("name" in response.json.get('errors')[0].get(MISSING_PARAMS).get("message"))
+    assert ("url" in response.json.get('errors')[0].get(MISSING_PARAMS).get("params"))
+    assert ("url" in response.json.get('errors')[0].get(MISSING_PARAMS).get("message"))
+    assert ("category" in response.json.get('errors')[0].get(MISSING_PARAMS).get("params"))
+    assert ("category" in response.json.get('errors')[0].get(MISSING_PARAMS).get("message"))
+    assert ("paid" in response.json.get('errors')[0].get(MISSING_PARAMS).get("params"))
+    assert ("paid" in response.json.get('errors')[0].get(MISSING_PARAMS).get("message"))
+
+    # Too many resources in the list
+    response = client.post('/api/v1/resources',
+                            json=[{} for x in range(0,201)],
+                            headers={'x-apikey': apikey})
+
+    assert (response.status_code == 422)
+    assert (isinstance(response.json.get("errors")[0].get("too-long"), dict))
+    assert (isinstance(response.json.get("errors")[0].get("too-long").get("message"), str))
+
+
+def test_create_multiple_resources(module_client, module_db, fake_auth_from_oc, fake_algolia_save):
+    client = module_client
+    apikey = get_api_key(client)
+
+    # Happy Path
+    url1 = f"http://example.org/{str(datetime.now())}"
+    url2 = f"http://example.com/{str(datetime.now())}"
+    data = [dict(
+                name="Some Name",
+                url=url1,
+                category="New Category",
+                languages=["Python", "New Language"],
+                paid=False,
+                notes="Some notes"),
+            dict(
+                name="Some Other Name",
+                url=url2,
+                category="Different Category",
+                languages=["Python", "New Language", "JSON"],
+                paid=True,
+                notes="Some notes")
+            ]
+    response = client.post('/api/v1/resources',
+                json=data,
+                headers={'x-apikey': apikey})
+
+    assert (response.status_code == 200)
+    response_data = response.get_json().get("data")
+    assert (len(response_data) == 2)
+    for res in response_data:
+        assert (res.get("url") == url1 or res.get("url") == url2)
+
+    # Sad path (duplicate URL)
+    data = [dict(
+                name="Some Name",
+                url=url1,
+                category="New Category",
+                languages=["Python", "New Language"],
+                paid=False,
+                notes="Some notes")]
+    response = client.post('/api/v1/resources',
+                json=data,
+                headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert (response.get_json().get("data") == None)
+    errors = response.get_json().get("errors")
+    assert (isinstance(errors, list))
+    assert (errors[0].get("index") == 0)
+    assert (errors[0].get("invalid-params").get("message"))
+    assert (errors[0].get("invalid-params").get("resource"))
+    assert (isinstance(errors[0].get("invalid-params").get("params"), list))
+
+    # Sad path, check index
+    data = [dict(
+                name="Some Name",
+                url="some.new.url",
+                category="New Category",
+                languages=["Python", "New Language"],
+                paid=False,
+                notes="Some notes"),
+            dict(
+                name="Other Name"
+            )]
+    response = client.post('/api/v1/resources',
+                json=data,
+                headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert (response.get_json().get("data") == None)
+    assert (response.get_json().get("errors")[0].get("index") == 1)
+
+
+def test_create_resource_wrong_type(module_client, module_db, fake_auth_from_oc, fake_algolia_save):
+    client = module_client
+    apikey = get_api_key(client)
+    response = client.post('/api/v1/resources',
+            json={"expected_error": "This should be a list"},
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("object" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.post('/api/v1/resources',
+            json=1,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("int" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.post('/api/v1/resources',
+            json=1.2,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("number" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.post('/api/v1/resources',
+            json=True,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("boolean" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.post('/api/v1/resources',
+            json="This should be a list",
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("string" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+
+def test_update_resource_wrong_type(module_client, module_db, fake_auth_from_oc, fake_algolia_save):
+    client = module_client
+    apikey = get_api_key(client)
+    response = client.put('/api/v1/resources/1',
+            json=[{"expected_error": "This should be a dict"}],
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("array" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.put('/api/v1/resources/1',
+            json=1,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("int" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.put('/api/v1/resources/1',
+            json=4.2,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("number" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.put('/api/v1/resources/1',
+            json=True,
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("boolean" in response.get_json().get("errors").get("invalid-type").get("message"))
+
+    response = client.put('/api/v1/resources/1',
+            json="This should be a dict",
+            headers={'x-apikey': apikey})
+    assert (response.status_code == 422)
+    assert ("string" in response.get_json().get("errors").get("invalid-type").get("message"))
 
 
 def test_update_resource(module_client, module_db, fake_auth_from_oc, fake_algolia_save):
@@ -589,25 +737,6 @@ def test_validate_resource(module_client, module_db, fake_auth_from_oc):
 
     apikey = get_api_key(client)
 
-    # Input validation
-    # IntegrityError
-    response = client.put("/api/v1/resources/2",
-                          json=dict(
-                              name="New name",
-                              languages=["New language"],
-                              category="New Category",
-                              url="https://new.url",
-                              paid=False,
-                              notes="New notes"
-                          ),
-                          headers={'x-apikey': apikey})
-
-    assert (response.status_code == 422)
-    assert (isinstance(response.json.get('errors').get(INVALID_PARAMS), dict))
-    assert (isinstance(response.json.get('errors').get(INVALID_PARAMS).get('message'), str))
-    assert ("url" in response.json.get('errors').get(INVALID_PARAMS).get("params"))
-    assert ("url" in response.json.get('errors').get(INVALID_PARAMS).get("message"))
-
     # Type Conversion
     response = client.put("/api/v1/resources/2",
                           json=dict(
@@ -657,8 +786,8 @@ def test_validate_resource(module_client, module_db, fake_auth_from_oc):
     response = client.put("/api/v1/resources/2",
                           headers={'x-apikey': apikey}
                           )
-    assert (isinstance(response.json.get('errors').get(MISSING_BODY), dict))
-    assert (isinstance(response.json.get('errors').get(MISSING_BODY).get('message'), str))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_BODY), dict))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_BODY).get('message'), str))
 
     response = client.put("api/v1/resources/1",
                           data='',
@@ -666,8 +795,8 @@ def test_validate_resource(module_client, module_db, fake_auth_from_oc):
                           headers={'x-apikey': apikey},
                           follow_redirects=True)
     assert (response.status_code == 422)
-    assert (isinstance(response.json.get('errors').get(MISSING_BODY), dict))
-    assert (isinstance(response.json.get('errors').get(MISSING_BODY).get('message'), str))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_BODY), dict))
+    assert (isinstance(response.json.get('errors')[0].get(MISSING_BODY).get('message'), str))
 
 
 def test_search(module_client, module_db, fake_auth_from_oc, fake_algolia_save, fake_algolia_search):
@@ -678,22 +807,22 @@ def test_search(module_client, module_db, fake_auth_from_oc, fake_algolia_save, 
 
     # Create resource and find it in the search results.
     resource = client.post("/api/v1/resources",
-                           json=dict(
+                           json=[dict(
                                name=f"{first_term}",
                                category="Website",
                                url=f"{first_term}",
                                paid=False,
-                           ),
+                           )],
                            headers={'x-apikey': apikey})
     result = client.get(f"/api/v1/search?q={first_term}")
 
     assert (resource.status_code == 200)
     assert (result.status_code == 200)
-    assert (result.json['data'][0]['url'] == resource.json['data'].get('url'))
+    assert (result.json['data'][0]['url'] == resource.json['data'][0].get('url'))
 
     # Update the resource and test that search results reflect changes
     updated_term = random_string()
-    resource_id = resource.json['data'].get('id')
+    resource_id = resource.json['data'][0].get('id')
     resource = client.put(f"/api/v1/resources/{resource_id}",
                           json=dict(url=f"{updated_term}",),
                           headers={'x-apikey': apikey})
@@ -783,12 +912,12 @@ def test_algolia_exception_error(module_client,
     assert (result.status_code == 500)
 
     resource = client.post("/api/v1/resources",
-                           json=dict(
+                           json=[dict(
                                name=f"{first_term}",
                                category="Website",
                                url=f"{first_term}",
                                paid=False,
-                           ),
+                           )],
                            headers={'x-apikey': apikey}
                            )
 
@@ -796,7 +925,7 @@ def test_algolia_exception_error(module_client,
 
     updated_term = random_string()
 
-    response = client.put(f"/api/v1/resources/{resource.json['data'].get('id')}",
+    response = client.put(f"/api/v1/resources/{resource.json['data'][0].get('id')}",
                           json=dict(
                               name="New name",
                               languages=["New language"],
@@ -824,12 +953,12 @@ def test_algolia_unreachable_host_error(module_client,
     assert (result.status_code == 500)
 
     resource = client.post("/api/v1/resources",
-                           json=dict(
+                           json=[dict(
                                name=f"{first_term}",
                                category="Website",
                                url=f"{first_term}",
                                paid=False,
-                           ),
+                           )],
                            headers={'x-apikey': apikey}
                            )
 
@@ -837,7 +966,7 @@ def test_algolia_unreachable_host_error(module_client,
 
     updated_term = random_string()
 
-    response = client.put(f"/api/v1/resources/{resource.json['data'].get('id')}",
+    response = client.put(f"/api/v1/resources/{resource.json['data'][0].get('id')}",
                           json=dict(
                               name="New name",
                               languages=["New language"],
@@ -880,12 +1009,12 @@ def false_validation(module_client,
     apikey = get_api_key(client)
 
     resource = client.post("/api/v1/resources",
-                           json=dict(
+                           json=[dict(
                                name=f"{first_term}",
                                category="Website",
                                url=f"{first_term}",
                                paid=False,
-                           ),
+                           )],
                            headers={'x-apikey': apikey}
                            )
 
@@ -1010,13 +1139,13 @@ def create_resource(client,
                     headers=None,
                     endpoint='/api/v1/resources'):
     return client.post(endpoint,
-                       json=dict(
+                       json=[dict(
                            name="Some Name" if not name else name,
                            url=f"http://example.org/{str(datetime.now())}" if not url else url,
                            category="New Category" if not category else category,
                            languages=["Python", "New Language"] if not languages else languages,
                            paid=False if not paid else paid,
-                           notes="Some notes" if not notes else notes),
+                           notes="Some notes" if not notes else notes)],
                        headers={'x-apikey': apikey} if not headers else headers)
 
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1108,6 +1108,12 @@ def test_method_not_allowed_handler(module_client):
 # Other Routes
 ##########################################
 
+def test_health_check(module_client):
+    response = module_client.get('/healthz')
+    assert (response.status_code == 200)
+    print(response.get_json())
+    assert (response.get_json().get("application").get("status") == "ok")
+
 
 # This method must come last if using the persistent client and db
 def test_rate_limit(module_client, module_db):


### PR DESCRIPTION
Fixes #206 

**EDIT:** The below examples in this description will be updated as I make changes to the interface, so assume that it is accurate and correct based on the latest commit. 

**EDIT 2:** There is an additional breaking change where when Algolia fails, it will now say in the response that the error has to do with Algolia. Now if Algolia fails, the request fails altogether so we always stay in sync. In addition, `PUT /resource/<id>` and `POST /resources` work without needing algolia as long as you're in the development environment.

This PR allows you to send a list of resources to the `POST /resources` endpoint to add all of them at once. If any resource in the list fails validation, none should be created until the issues are fixed, allowing for subsequent similar requests but with the issues fixed.

The happy path looks like this.

Request:
```json
[
    {
    	"name": "Legit new resource",
    	"url": "legitresource.com",
    	"category": "Computer Science",
    	"paid": false,
        "notes": ""
    },
    {
    	"name": "Another Legit new resource",
    	"url": "anotherlegitresource.com",
    	"category": "Computer Science",
    	"paid": false,
        "notes": ""
    }
]
```
Response:
```json
{
  "apiVersion": "1.0",
  "data": [
    {
      "category": "Computer Science",
      "created_at": "2019-09-12 04:10:07",
      "downvotes": 0,
      "id": 2139,
      "languages": [],
      "last_updated": "",
      "name": "Legit new resource",
      "notes": "",
      "paid": false,
      "times_clicked": 0,
      "upvotes": 0,
      "url": "legitresource.com"
    },
    {
      "category": "Computer Science",
      "created_at": "2019-09-12 04:10:07",
      "downvotes": 0,
      "id": 2140,
      "languages": [],
      "last_updated": "",
      "name": "Another Legit new resource",
      "notes": "",
      "paid": false,
      "times_clicked": 0,
      "upvotes": 0,
      "url": "anotherlegitresource.com"
    }
  ],
  "status": "ok",
  "status_code": 200
}
```

The sad path of both failing validation looks like this.

Request:
```json
[
    {
    	"name": "Legit new resource",
        "notes": ""
    },
    {
    	"name": "Another Legit new resource",
    	"url": "anotherlegitresource.com"
    }
]
```
Response:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "index": 0,
      "missing-params": {
        "message": " The following params were missing: url, category, paid.",
        "params": [
          "url",
          "category",
          "paid"
        ]
      }
    },
    {
      "index": 1,
      "invalid-params": {
        "message": "The following params were invalid: url. Resource id 2140 already has this URL.",
        "params": [
          "url"
        ],
        "resource": "https://resources.operationcode.org/api/v1/2140"
      },
      "missing-params": {
        "message": " The following params were missing: category, paid.",
        "params": [
          "category",
          "paid"
        ]
      }
    }
  ],
  "status": "Unprocessable Entity",
  "status_code": 422
}
```
Notice how the list of errors gives an index number. This index maps to the index number of the list that was submitted. The first one in this example request was missing `url`, `category` and `paid`, so it describes that. The second one also had a URL, so that failed validation for even more reasons.

The sad path of only the second one failing validation looks like this.

```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "index": 1,
      "invalid-params": {
        "message": "The following params were invalid: url. Resource id 2140 already has this URL.",
        "params": [
          "url"
        ],
        "resource": "https://resources.operationcode.org/api/v1/2140"
      },
      "missing-params": {
        "message": " The following params were missing: category, paid.",
        "params": [
          "category",
          "paid"
        ]
      }
    }
  ],
  "status": "Unprocessable Entity",
  "status_code": 422
}
```

As you can see, if the first resource is fine, then `index` is not a key with an error object in the response. The only resource of the batch that failed validation is index 1 (i.e., the second one in the list).

The API now responds with a specific error when you submit the wrong type to a create or update endpoint. It can recognize when the user submits an "object", "int", "array", "number", "boolean", or "string". If any of these are submitted other than the correct type expected, it will respond with the expectation, as shown below. 

The sad path of submitting an array to the update endpoint:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": {
    "invalid-type": {
      "message": "Expected resource object, but found array"
    }
  },
  "status": "Unprocessable Entity",
  "status_code": 422
}
```

The sad path of submitting an object to the create endpoint:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": {
    "invalid-type": {
      "message": "Expected list of resources objects, but found object"
    }
  },
  "status": "Unprocessable Entity",
  "status_code": 422
}
```

The sad path of submitting too many resources (more than 200) looks like this:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "too-long": {
        "message": "This endpoint will accept a max of 200 resources"
      }
    }
  ],
  "status": "Unprocessable Entity",
  "status_code": 422
}
```

**Algolia errors**

`GET /search` Response if Algolia fails:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "algolia-failed": {
        "message": "Failed to get resources from Algolia"
      }
    }
  ],
  "status": "Server Error",
  "status_code": 500
}
```

`PUT /resources/<id>` Response if Algolia fails:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "algolia-failed": {
        "message": "Algolia failed to update index for resource 'Name of Resource'"
      }
    }
  ],
  "status": "Server Error",
  "status_code": 500
}
```

`POST /resources` Response if Algolia fails:
```json
{
  "apiVersion": "1.0",
  "data": null,
  "errors": [
    {
      "algolia-failed": {
        "message": "Algolia failed to index resources"
      }
    }
  ],
  "status": "Server Error",
  "status_code": 500
}
```