### PR TITLE
Added 'paid' algolia filtering to search endpoint

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -243,8 +243,22 @@ def search_results():
     page = request.args.get('page', 0, int)
     page_size = request.args.get('page_size', Config.RESOURCE_PAGINATOR.per_page, int)
 
+    # Fetch the filter params from the url, if they were provided.
+    paid = request.args.get('paid')
+    filters = ''
+
+    # Filter on paid
+    if isinstance(paid, str):
+        paid = paid.lower()
+        # algolia filters boolean attributes with either 0 or 1
+        if paid == 'true':
+            filters += 'paid=1'
+        elif paid == 'false':
+            filters += 'paid=0'
+
     try:
         search_result = index.search(f'{term}', {
+            'filters': filters,
             'page': page,
             'hitsPerPage': page_size
         })

--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -91,6 +91,12 @@ paths:
           schema:
             type: string
           required: true
+        - in: query
+          name: paid
+          required: false
+          description: Whether the data is paid or not. To search for *free* resources, make a `GET` request to `/search?paid=false`.
+          schema:
+            type: boolean
       responses:
         200:
           description: Search results
@@ -479,12 +485,9 @@ paths:
         - in: query
           name: paid
           required: false
-          description: Whether the resource is paid or not. To search for *FREE* resources, make a `GET` request to `/resources?paid=false`.
+          description: Whether the resource is paid or not. To search for *free* resources, make a `GET` request to `/resources?paid=false`.
           schema:
             type: boolean
-            enum:
-              - true
-              - false
         - in: query
           name: language
           required: false

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -594,6 +594,22 @@ def test_search(module_client, module_db, fake_auth_from_oc, fake_algolia_save, 
     assert (result.json['data'][0]['url'] == resource.json['data'].get('url'))
 
 
+def test_search_paid_filter(module_client, module_db, fake_auth_from_oc, fake_algolia_save, fake_algolia_search):
+    client = module_client
+
+    # Test on the unpaid resources
+    result = client.get("/api/v1/search?paid=false")
+    assert (result.status_code == 200)
+
+    # Test on the paid resources
+    result = client.get("/api/v1/search?paid=true")
+    assert (result.status_code == 200)
+
+    # Test with invalid paid attribute given ( defaults to all )
+    result = client.get("/api/v1/search?paid=something")
+    assert (result.status_code == 200)
+
+
 def test_algolia_exception_error(module_client, module_db, fake_auth_from_oc, fake_algolia_exception):
     client = module_client
     first_term = random_string()


### PR DESCRIPTION
Hello!
Refers Issue [#194 ](https://github.com/OperationCode/resources_api/issues/194)

I have added 'paid' attribute filtering to the search endpoint using algolia filters, due to not having API key I haven't been able to test it thoroughly.

Possible issue I noticed ( unrelated to this PR ) is that the algolia query API search has a limit of 512 characters where if the user typed a really long query, it would return a 500 error

Let me know if there is anything else I can do, this is my first time 😅 