### PR TITLE
Update examples from inline JSON to YAML

### DIFF
--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -47,16 +47,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiKeyResponse'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': {
-                    'apikey': 'yourapikey',
-                    'email': 'your@email.com'
-                  }
-                  'status': 'ok',
-                  'status_code': 200
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                  apikey: '1234567890'
+                  email: 'your@email.com'
+                status: 'ok'
+                status_code: 200
         400:
           $ref: '#/components/responses/BadRequest'
         401:
@@ -65,18 +62,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': null,
-                  'errors': {
-                    'invalid-credentials': {
-                        'message': 'The email or password you submitted is incorrect'
-                    }
-                  },
-                  'status': 'Unauthorized',
-                  'status_code': 401
-                }
+              example:
+                apiVersion: '1.0'
+                data: null
+                errors:
+                  invalid-credentials:
+                    message: 'The email or password you submitted is incorrect'
+                status: 'Unauthorized'
+                status_code: 401
 
   /search:
     get:
@@ -104,34 +97,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchResponse'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': [
-                      {
-                          'category': 'Tutorials',
-                          'created_at': '2019-05-25 18:52:15',
-                          'downvotes': 0,
-                          'id': 953,
-                          'languages': [
-                              'C'
-                          ],
-                          'last_updated': ',
-                          'name': 'C Tutorial',
-                          'notes': 'Learn C with our popular C tutorial, which will take you from the very basics of C all the way through sophisticated topics like binary trees and data structures.',
-                          'paid': false,
-                          'times_clicked': 0,
-                          'upvotes': 0,
-                          'url': 'https://www.cprogramming.com/tutorial/c-tutorial.html'
-                      }
-                  ],
-                  'number_of_pages': 1,
-                  'page': 0,
-                  'records_per_page': 20,
-                  'status': 'ok',
-                  'status_code': 200,
-                  'total_count': 1
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                  - category': 'Tutorials'
+                    created_at: '2019-05-25 18:52:15'
+                    downvotes: 0
+                    id: 953
+                    languages:
+                      - 'C'
+                    last_updated: '2019-05-25 18:52:15'
+                    name: 'C Tutorial'
+                    notes: 'Learn C with our popular C tutorial, which will take you from the very basics of C all the way through sophisticated topics like binary trees and data structures.'
+                    paid: false
+                    times_clicked: 0
+                    upvotes: 0
+                    url: 'https://www.cprogramming.com/tutorial/c-tutorial.html'
+                number_of_pages: 1
+                page: 0
+                records_per_page: 20
+                status: 'ok'
+                status_code: 200
+                total_count: 1
         404:
           $ref: '#/components/responses/NotFound'
   /categories:
@@ -147,39 +134,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Category'
-              example: |
-                {
-                  'apiVersion':'1.0',
-                  'data':[
-                    {'id':1,'name':'Books'},
-                    {'id':2,'name':'Code Challenges'},
-                    {'id':3,'name':'Getting Started'},
-                    {'id':4,'name':'Tutorials'},
-                    {'id':5,'name':'Online Courses'},
-                    {'id':6,'name':'Jobs'},
-                    {'id':7,'name':'Tools'},
-                    {'id':8,'name':'Programming for Kids'},
-                    {'id':9,'name':'REPL/Code Simulators'},
-                    {'id':10,'name':'Design'},
-                    {'id':11,'name':'Computer Hardware'},
-                    {'id':12,'name':'Computer Networking'},
-                    {'id':13,'name':'Cloud IDEs'},
-                    {'id':14,'name':'Docker'},
-                    {'id':15,'name':'Regular Expressions'},
-                    {'id':16,'name':'Mentorship'},
-                    {'id':17,'name':'News'},
-                    {'id':18,'name':'Back End Dev'},
-                    {'id':19,'name':'Mobile Dev'},
-                    {'id':20,'name':'Cheat Sheets'}],
-                  'has_next':true,
-                  'has_prev':false,
-                  'number_of_pages':4,
-                  'page':1,
-                  'records_per_page':20,
-                  'status':'ok',
-                  'status_code':200,
-                  'total_count':72
-                }
+              example:
+                  apiVersion: '1.0'
+                  data:
+                    - id: 1
+                      name: 'Books'
+                    - id: 2
+                      name: 'Code Challenges'
+                    - id: 3
+                      name: 'Getting Started'
+                    - id: 4
+                      name: 'Tutorials'
+                    - id: 5
+                      name: 'Online Courses'
+                    - id: 6
+                      name: 'Jobs'
+                    - id: 7
+                      name: 'Tools'
+                    - id: 8
+                      name: 'Programming for Kids'
+                    - id: 9
+                      name: 'REPL/Code Simulators'
+                    - id: 10
+                      name: 'Design'
+                    - id: 11
+                      name: 'Computer Hardware'
+                    - id: 12
+                      name: 'Computer Networking'
+                    - id: 13
+                      name: 'Cloud IDEs'
+                    - id: 14
+                      name: 'Docker'
+                    - id: 15
+                      name: 'Regular Expressions'
+                    - id: 1
+                      name: 'Mentorship'
+                    - id: 1
+                      name: 'News'
+                    - id: 1
+                      name: 'Back End Dev'
+                    - id: 1
+                      name: 'Mobile Dev'
+                    - id: 1
+                      name: 'Cheat Sheets'
+                  has_next: true
+                  has_prev: false
+                  number_of_pages: 4
+                  page: 1
+                  records_per_page: 20
+                  status: 'ok'
+                  status_code: 200
+                  total_count: 72
         404:
           $ref: '#/components/responses/NotFound'
   /categories/{id}:
@@ -205,16 +210,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Category_data'
-              example: |
-                {
-                  'apiVersion':'1.0',
-                  'data':{
-                    'id':1,
-                    'name':'Books',
-                  },
-                  'status':'ok',
-                  'status_code':200
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                  id: 1
+                  name: 'Books'
+                status: 'ok'
+                status_code: 200
         404:
           $ref: '#/components/responses/NotFound'
   /languages:
@@ -230,39 +232,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Language'
-              example: |
-                    {
-                      'apiVersion':'1.0',
-                      'data':[
-                        {'id':1,'name':'multiple'},
-                        {'id':2,'name':'Python'},
-                        {'id':3,'name':'Unix/Linux/*nix'},
-                        {'id':4,'name':'Bash'},
-                        {'id':5,'name':'C'},
-                        {'id':6,'name':'Sysadmin'},
-                        {'id':7,'name':'JavaScript'},
-                        {'id':8,'name':'HTML'},
-                        {'id':9,'name':'PHP'},
-                        {'id':10,'name':'Ruby'},
-                        {'id':11,'name':'Aspectwerkz'},
-                        {'id':12,'name':'Artificial Intelligence'},
-                        {'id':13,'name':'C++'},
-                        {'id':14,'name':'MongoDB'},
-                        {'id':15,'name':'SQL'},
-                        {'id':16,'name':'R'},
-                        {'id':17,'name':'GraphQL'},
-                        {'id':18,'name':'Swift'},
-                        {'id':19,'name':'Android'},
-                        {'id':20,'name':'CSS'}],
-                      'has_next':true,
-                      'has_prev':false,
-                      'number_of_pages':4,
-                      'page':1,
-                      'records_per_page':20,
-                      'status':'ok',
-                      'status_code':200,
-                      'total_count':73
-                    }
+              example:
+                apiVersion: '1.0'
+                data:
+                  - id: 1
+                    name: 'multiple'
+                  - id: 2
+                    name: 'Python'
+                  - id: 3
+                    name: 'Unix/Linux/*nix'
+                  - id: 4
+                    name: 'Bash'
+                  - id: 5
+                    name: 'C'
+                  - id: 6
+                    name: 'Sysadmin'
+                  - id: 7
+                    name: 'JavaScript'
+                  - id: 8
+                    name: 'HTML'
+                  - id: 9
+                    name: 'PHP'
+                  - id: 10
+                    name: 'Ruby'
+                  - id: 11
+                    name: 'Aspectwerkz'
+                  - id: 12
+                    name: 'Artificial Intelligence'
+                  - id: 13
+                    name: 'C++'
+                  - id: 14
+                    name: 'MongoDB'
+                  - id: 15
+                    name: 'SQL'
+                  - id: 16
+                    name: 'R'
+                  - id: 17
+                    name: 'GraphQL'
+                  - id: 18
+                    name: 'Swift'
+                  - id: 19
+                    name: 'Android'
+                  - id: 20
+                    name: 'CSS'
+                has_next: true
+                has_prev: false
+                number_of_pages: 4
+                page: 1
+                records_per_page: 20
+                status: 'ok'
+                status_code: 200
+                total_count: 73
         404:
           $ref: '#/components/responses/NotFound'
   /languages/{id}:
@@ -288,16 +308,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Language_data'
-              example: |
-                {
-                  'apiVersion':'1.0',
-                  'data':{
-                    'id':2,
-                    'name':'Python',
-                  },
-                  'status':'ok',
-                  'status_code':200
-                }
+              example:
+                apiVersion : '1.0'
+                data:
+                  id: 2
+                  name: 'Python'
+                status: 'ok'
+                status_code: 200
         404:
           $ref: '#/components/responses/NotFound'
   /resources/{id}:
@@ -323,27 +340,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Resource'
-              example: |
-                {
-                  'apiVersion':'1.0',
-                  'data':{
-                    'category':'Books',
-                    'created_at':'2019-06-15 17:55:32',
-                    'downvotes':0,
-                    'id':3,
-                    'languages':[],
-                    'last_updated':',
-                    'name':'Free Tech Books',
-                    'notes':'Focuses on general computer science concepts rather than a specific language',
-                    'paid':false,
-                    'times_clicked':0,
-                    'upvotes':0,
-                    'url':'http://www.freetechbooks.com/'
-
-                  },
-                  'status':'ok',
-                  'status_code':200
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                  - category: 'Books'
+                    created_at: '2019-06-15 17:55:32'
+                    downvotes: 0
+                    id: 3
+                    languages: []
+                    last_updated: '2019-06-15 17:55:32'
+                    name: 'Free Tech Books'
+                    notes: 'Focuses on general computer science concepts rather than a specific language'
+                    paid: false
+                    times_clicked: 0
+                    upvotes: 0
+                    url: 'http://www.freetechbooks.com/'
+                status: 'ok'
+                status_code: 200
         404:
           $ref: '#/components/responses/NotFound'
     put:
@@ -356,10 +369,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Resource'
-            example: |
-              {
-                'name': 'Updated Book Title'
-              }
+            example:
+              name: 'Updated Book Title'
         required: true
       parameters:
         - name: id
@@ -378,27 +389,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Resource'
-              example: |
-                {
-                    'apiVersion': '1.0',
-                    'data': {
-                        'category': 'Tutorial',
-                        'created_at': '2019-07-21 15:41:19',
-                        'downvotes': 0,
-                        'id': 2137,
-                        'languages': [],
-                        'last_updated': '2019-07-22 16:05:53',
-                        'name': 'Updated Book Title',
-                        'notes': null,
-                        'paid': false,
-                        'times_clicked': 3,
-                        'upvotes': 1,
-                        'url': 'http://www.test.com'
-                    },
-                    'status': 'ok',
-                    'status_code': 200
-                  }
-
+              example:
+                apiVersion: '1.0'
+                data:
+                  - category: 'Tutorial'
+                    created_at: '2019-07-21 15:41:19'
+                    downvotes: 0
+                    id: 2137
+                    languages: []
+                    last_updated: '2019-07-22 16:05:53'
+                    name: 'Updated Book Title'
+                    notes: null
+                    paid: false
+                    times_clicked: 3
+                    upvotes: 1
+                    url: 'http://www.test.com'
+                status: 'ok'
+                status_code: 200
         404:
           $ref: '#/components/responses/NotFound'
         401:
@@ -409,23 +416,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': null,
-                  'errors': {
-                    'invalid-params': {
-                        'message': 'The following params were invalid: url. Resource id 2137 already has this URL.',
-                        'params': [
-                            'url'
-                        ],
-                        'resource': 'https://resources.operationcode.org/api/v1/2137'
-                    }
-                  },
-                  'status': 'Unprocessable Entity',
-                  'status_code': 422
-                }
-
+              example:
+                apiVersion: '1.0'
+                data: null
+                errors:
+                  invalid-params:
+                      message: 'The following params were invalid: url. Resource id 2137 already has this URL.'
+                      params:
+                        - 'url'
+                      resource: 'https://resources.operationcode.org/api/v1/2137'
+                status: 'Unprocessable Entity'
+                status_code: 422
       security:
       - ApiKeyAuth: []
   /resources/{id}/click:
@@ -452,26 +453,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Resource_data'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': {
-                      'category': 'Books',
-                      'created_at': '2019-04-28 22:18:34',
-                      'downvotes': 0,
-                      'id': 10,
-                      'languages': [],
-                      'last_updated': '2019-07-26 13:47:52',
-                      'name': 'Thinking Forth',
-                      'notes': null,
-                      'paid': false,
-                      'times_clicked': 2,
-                      'upvotes': 0,
-                      'url': 'http://thinking-forth.sourceforge.net/'
-                  },
-                  'status': 'ok',
-                  'status_code': 200
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                    - category: 'Books'
+                      created_at: '2019-04-28 22:18:34'
+                      downvotes: 0
+                      id: 10
+                      languages: []
+                      last_updated: '2019-07-26 13:47:52'
+                      name: 'Thinking Forth'
+                      notes: null
+                      paid: false
+                      times_clicked: 2
+                      upvotes: 0
+                      url: 'http://thinking-forth.sourceforge.net/'
+                status: 'ok'
+                status_code: 200
         404:
           $ref: '#/components/responses/NotFound'
 
@@ -515,35 +513,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FilteredResourcesResponse'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data':
-                  [
-                      {
-                        'category': 'Tutorial',
-                        'created_at': '2019-07-21 15:41:19',
-                        'downvotes': 0,
-                        'id': 2137,
-                        'languages': [],
-                        'last_updated': '2019-07-22 17:39:50',
-                        'name': 'Some, but not ALL of the knowledge',
-                        'notes': null,
-                        'paid': false,
-                        'times_clicked': 3,
-                        'upvotes': 1,
-                        'url': 'http://www.test.com'
-                      }
-                  ],
-                    'has_next': false,
-                    'has_prev': false,
-                    'number_of_pages': 1,
-                    'page': 1,
-                    'records_per_page': 20,
-                    'status': 'ok',
-                    'status_code': 200,
-                    'total_count': 1
-                }
+              example:
+                apiVersion: '1.0'
+                data:
+                  - category': 'Tutorial'
+                    created_at: '2019-07-21 15:41:19'
+                    downvotes: 0
+                    id: 2137
+                    languages: []
+                    last_updated: '2019-07-22 17:39:50'
+                    name: 'Some, but not ALL of the knowledge'
+                    notes: null
+                    paid: false
+                    times_clicked: 3
+                    upvotes: 1
+                    url: 'http://www.test.com'
+                has_next: false
+                has_prev: false
+                number_of_pages: 1
+                page: 1
+                records_per_page: 20
+                status: 'ok'
+                status_code: 200
+                total_count: 1
         404:
           $ref: '#/components/responses/NotFound'
 
@@ -553,18 +545,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': null,
-                  'errors': {
-                    'unprocessable-entity': {
-                      'message': 'The value for "updated_after" is invalid'
-                    }
-                  },
-                  'status': 'Unprocessable Entity',
-                  'status_code': 422
-                }
+              example:
+                apiVersion: '1.0'
+                data: null
+                errors:
+                  unprocessable-entity:
+                    message: 'The value for "updated_after" is invalid'
+                status: 'Unprocessable Entity'
+                status_code: 422
 
     post:
       summary: Create Resource
@@ -576,13 +564,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateResourceRequest'
-            example: |
-              {
-                    'category': 'Tutorial',
-                    'name': 'CSS Tutorial',
-                    'paid': false,
-                    'url': 'https://www.w3schools.com/css/'
-                }
+            example:
+              category: 'Tutorial'
+              name: 'CSS Tutorial'
+              paid: false
+              url: 'https://www.w3schools.com/css/'
         required: true
       responses:
         200:
@@ -591,26 +577,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Resource'
-              example: |
-                    {
-                        'apiVersion': '1.0',
-                        'data': {
-                            'category': 'Tutorial',
-                            'created_at': '2019-07-21 15:41:19',
-                            'downvotes': 0,
-                            'id': 2137,
-                            'languages': ['CSS'],
-                            'last_updated': '2019-07-22 16:05:53',
-                            'name': 'CSS Tutorial',
-                            'notes': null,
-                            'paid': false,
-                            'times_clicked': 3,
-                            'upvotes': 1,
-                            'url': 'https://www.w3schools.com/css/'
-                        },
-                        'status': 'ok',
-                        'status_code': 200
-                      }
+              example:
+                apiVersion: '1.0'
+                data:
+                  category: 'Tutorial'
+                  created_at: '2019-07-21 15:41:19'
+                  downvotes: 0
+                  id: 2137
+                  languages:
+                    - 'CSS'
+                  last_updated: '2019-07-22 16:05:53'
+                  name: 'CSS Tutorial'
+                  notes: null
+                  paid: false
+                  times_clicked: 3
+                  upvotes: 1
+                  url: 'https://www.w3schools.com/css/'
+                status: 'ok'
+                status_code: 200
         400:
           $ref: '#/components/responses/BadRequest'
         401:
@@ -621,31 +605,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: |
-                {
-                  'apiVersion': '1.0',
-                  'data': null,
-                  'errors': {
-                    'invalid-params': {
-                        'message': 'The following params were invalid: url. Resource id 2137 already has this URL.',
-                        'params': [
-                            'url'
-                        ],
-                        'resource': 'https://resources.operationcode.org/api/v1/2137'
-                    },
-                    'missing-params': {
-                        'message': 'The following params were missing: name, category, paid.',
-                        'params': [
-                            'name',
-                            'category',
-                            'paid'
-                        ]
-                    }
-                  },
-                  'status': 'Unprocessable Entity',
-                  'status_code': 422
-                }
-
+              example:
+                  apiVersion: '1.0'
+                  data: null
+                  errors:
+                    invalid-params:
+                      - message: 'The following params were invalid: url. Resource id 2137 already has this URL.'
+                        params:
+                          - url
+                        resource: 'https://resources.operationcode.org/api/v1/2137'
+                    missing-params:
+                        message: 'The following params were missing: name, category, paid.'
+                        params:
+                          - name
+                          - category
+                          - paid
+                  status: 'Unprocessable Entity'
+                  status_code: 422
       security:
       - ApiKeyAuth: []
 
@@ -1025,17 +1001,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-          example: |
-            {
-              'apiVersion': '1.0',
-              'data': null,
-              'errors': {
-                'not-found': {
-                  'message': 'The resource you requested does not exist.'
-              },
-              'status': 'Not Found',
-              'status_code': 404
-            }
+          example:
+            apiVersion: '1.0'
+            data: null
+            errors:
+              not-found:
+                message: 'The resource you requested does not exist.'
+            status: 'Not Found'
+            status_code: 404
 
     Unauthorized:
       description: Unauthorized access
@@ -1062,18 +1035,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-          example: |
-            {
-                'apiVersion': '1.0',
-                'data': null,
-                'errors': {
-                    'unauthorized': {
-                        'message': 'You must provide a valid API token in the x-apikey header.'
-                    }
-                },
-                'status': 'Unauthorized',
-                'status_code': 401
-            }
+          example:
+            apiVersion: '1.0'
+            data: null
+            errors:
+              unauthorized:
+                message: 'You must provide a valid API token in the x-apikey header.'
+            status: 'Unauthorized'
+            status_code: 401
 
     BadRequest:
       description: Bad request
@@ -1081,17 +1050,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-          example: |
-            {
-              'apiVersion': '1.0',
-              'data': null,
-              'errors': {
-                'bad-request': {
-                  'message': '400 Bad Request: Failed to decode JSON object: Expecting ',' delimiter: line 3 column 2 (char 25)'
-              },
-              'status': 'Bad Request',
-              'status_code': 400
-            }
+          example:
+            apiVersion: '1.0'
+            data: null
+            errors:
+              bad-request:
+                message: "400 Bad Request: Failed to decode JSON object: Expecting ',' delimiter: line 3 column 2 (char 25)"
+            status: 'Bad Request'
+            status_code: 400
 
   securitySchemes:
     ApiKeyAuth:


### PR DESCRIPTION
@kylemh pointed out that we have a problem in production with the examples not rendering properly. I have not figured out a root cause, but I suspect a change was made to the library we're using to render the docs. In any case, I fixed it now per [the spec](https://swagger.io/docs/specification/adding-examples/).

Before:
<img width="641" alt="Screen Shot 2019-10-13 at 11 20 51 PM" src="https://user-images.githubusercontent.com/2008701/66729310-2b9b5b80-ee10-11e9-9e66-e773ed466188.png">

After:
<img width="658" alt="Screen Shot 2019-10-13 at 11 21 06 PM" src="https://user-images.githubusercontent.com/2008701/66729313-3229d300-ee10-11e9-9173-19bd6f0dbb1a.png">
