### PR TITLE
Added Language & Category filtering to search endpoint

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -245,20 +245,36 @@ def search_results():
 
     # Fetch the filter params from the url, if they were provided.
     paid = request.args.get('paid')
-    filters = ''
+    category = request.args.get('category')
+    languages = request.args.getlist('languages')
+    filters = []
 
     # Filter on paid
     if isinstance(paid, str):
         paid = paid.lower()
         # algolia filters boolean attributes with either 0 or 1
         if paid == 'true':
-            filters += 'paid=1'
+            filters.append('paid=1')
         elif paid == 'false':
-            filters += 'paid=0'
+            filters.append('paid=0')
+
+    # Filter on category
+    if isinstance(category, str):
+        filters.append(
+            f"category:{category}"
+        )
+
+    # Filter on languages
+    if isinstance(languages, list):
+        for i, _ in enumerate(languages):
+            languages[i] = f"languages:{languages[i]}"
+
+        # joining all possible language values to algolia filter query
+        filters.append(f"( {' OR '.join(languages)} )")
 
     try:
         search_result = index.search(f'{term}', {
-            'filters': filters,
+            'filters': "AND".join(filters),
             'page': page,
             'hitsPerPage': page_size
         })

--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -97,6 +97,18 @@ paths:
           description: Whether the data is paid or not. To search for *free* resources, make a `GET` request to `/search?paid=false`.
           schema:
             type: boolean
+        - in: query
+          name: languages
+          required: false
+          description: Language(s) of the resource to search. For example, to filter for JavaScript and Python resources, make a `GET` request to `/search?languages=python&languages=javascript`.
+          schema:
+            type: array of strings
+        - in: query
+          name: category
+          required: false
+          description: Category of the resource. For example, to filter for book resources, make a `GET` request to `/search?category=books`.
+          schema:
+            type: string
       responses:
         200:
           description: Search results

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -646,6 +646,31 @@ def test_search_paid_filter(module_client, module_db, fake_auth_from_oc, fake_al
     result = client.get("/api/v1/search?paid=something")
     assert (result.status_code == 200)
 
+def test_search_category_filter(module_client, module_db, fake_auth_from_oc, fake_algolia_save, fake_algolia_search):
+    client = module_client
+
+    # Test on book resources
+    result = client.get("/api/v1/search?category=books")
+    assert (result.status_code == 200)
+
+    result = client.get("/api/v1/search?category=Books")
+    assert (result.status_code == 200)
+
+
+def test_search_language_filter(module_client, module_db, fake_auth_from_oc, fake_algolia_save, fake_algolia_search):
+    client = module_client
+
+    # Test on Python resources
+    result = client.get("/api/v1/search?languages=python")
+    assert (result.status_code == 200)
+    
+    result = client.get("/api/v1/search?languages=Python")
+    assert (result.status_code == 200)
+
+    # Test on multiple languages
+    result = client.get("/api/v1/search?languages=python&languages=javascript")
+    assert (result.status_code == 200)
+    
 
 def test_algolia_exception_error(module_client, module_db, fake_auth_from_oc, fake_algolia_exception):
     client = module_client


### PR DESCRIPTION
Refers [Issue#194](https://github.com/OperationCode/resources_api/issues/194)
Added Language & category filtering to search endpoint with tests & docs.

Please let me know if there is anything that is needed

Edit:
Tests will fail currently because need actual API Key to be able to set_settings correctly for the attributes that need faceting for algolia, otherwise they should work fine. any thoughts? 

Possible solution:
Add the attributes throught the [dashboard](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-arrays/#using-the-dashboard) and remove the set_settings part from the endpoint, that should make the tests work correctly without having to use the API key
