### PR TITLE
Filter by multiple languages on List Resources endpoint

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -165,7 +165,7 @@ def get_resources():
     """
     Gets a paginated list of resources.
 
-    If the URL parameters `language` or `category` are found
+    If the URL parameters `languages` or `category` are found
     in the request, the list will be filtered by these parameters.
 
     The filters are case insensitive.
@@ -173,20 +173,21 @@ def get_resources():
     resource_paginator = utils.Paginator(Config.RESOURCE_PAGINATOR, request)
 
     # Fetch the filter params from the url, if they were provided.
-    language = request.args.get('language')
+    languages = request.args.getlist('languages')
     category = request.args.get('category')
     updated_after = request.args.get('updated_after')
     paid = request.args.get('paid')
 
     q = Resource.query
 
-    # Filter on language
-    if language:
+    # Filter on languages
+    if languages:
+        # Take the list of languages they pass in, join them all with OR
         q = q.filter(
-            Resource.languages.any(
-                Language.name.ilike(language)
+            or_(*map(Resource.languages.any,
+                map(Language.name.ilike, languages))
+                )
             )
-        )
 
     # Filter on category
     if category:

--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -499,9 +499,9 @@ paths:
           schema:
             type: boolean
         - in: query
-          name: language
+          name: languages
           required: false
-          description: Language or main technical focus of resource. For example, to filter for Python resources, make a `GET` request to `/resources?language=python`.
+          description: Language(s) of the resource. For example, to filter for Python and JavaScript resources, make a `GET` request to `/resources?languages=python&languages=javascript`
           schema:
             type: string
         - in: query

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -188,12 +188,20 @@ def test_paid_filter_defaults_all_when_invalid_paid_parameter(module_client, mod
 def test_filters(module_client, module_db):
     client = module_client
 
-    # Filter by language
-    response = client.get('api/v1/resources?language=python')
+    # Filter by one language
+    response = client.get('api/v1/resources?languages=python')
 
     for resource in response.json['data']:
         assert (isinstance(resource.get('languages'), list))
         assert ('Python' in resource.get('languages'))
+
+    # Filter by multiple languages
+    response = client.get('api/v1/resources?languages=python&languages=javascript')
+
+    for resource in response.json['data']:
+        assert (isinstance(resource.get('languages'), list))
+        assert (('Python' in resource.get('languages')) or
+            ('JavaScript' in resource.get('languages')))
 
     # Filter by category
     response = client.get('api/v1/resources?category=Back%20End%20Dev')
@@ -663,14 +671,14 @@ def test_search_language_filter(module_client, module_db, fake_auth_from_oc, fak
     # Test on Python resources
     result = client.get("/api/v1/search?languages=python")
     assert (result.status_code == 200)
-    
+
     result = client.get("/api/v1/search?languages=Python")
     assert (result.status_code == 200)
 
     # Test on multiple languages
     result = client.get("/api/v1/search?languages=python&languages=javascript")
     assert (result.status_code == 200)
-    
+
 
 def test_algolia_exception_error(module_client, module_db, fake_auth_from_oc, fake_algolia_exception):
     client = module_client


### PR DESCRIPTION
#234 Allows you to filter the search endpoint by multiple languages. This PR is to maintain consistency with both endpoints, but also because it's a useful feature in its own right. It should be noted that Algolia will display results for anything kind of close to either language passed in, whereas the List Resources endpoint makes it a hard secondary filter. So if you try to list Resources for both `Scala` and `Python` for example and there are none that have both of those, it will return no results.