### PR TITLE
Fix Update Resource schema

### DIFF
--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -380,7 +380,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Resource'
+              $ref: '#/components/schemas/ResourceRequest'
             example:
               name: 'Updated Book Title'
         required: true


### PR DESCRIPTION
The Update Resource endpoint used the incorrect `Request Body Schema`. This updates it to the correct schema.

Before:
<img width="641" alt="Screen Shot 2019-10-20 at 10 18 06 AM" src="https://user-images.githubusercontent.com/2008701/67161738-01bbca80-f323-11e9-898a-d90c61b12600.png">
After:
<img width="614" alt="Screen Shot 2019-10-20 at 10 18 38 AM" src="https://user-images.githubusercontent.com/2008701/67161742-07b1ab80-f323-11e9-857b-7dd530606c06.png">
