### PR TITLE
Fix for search endpoint filtering

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -251,7 +251,7 @@ def search_results():
     filters = []
 
     # Filter on paid
-    if isinstance(paid, str):
+    if paid:
         paid = paid.lower()
         # algolia filters boolean attributes with either 0 or 1
         if paid == 'true':
@@ -260,15 +260,19 @@ def search_results():
             filters.append('paid=0')
 
     # Filter on category
-    if isinstance(category, str):
+    if category:
+        # to not let double quotes conflict with algolia filter format
+        category = category.replace('"', "'")
+
         filters.append(
-            f"category:{category}"
+            f'category: "{category}"'
         )
 
     # Filter on languages
-    if isinstance(languages, list):
+    if languages and '' not in languages:
         for i, _ in enumerate(languages):
-            languages[i] = f"languages:{languages[i]}"
+            # to not let double quotes conflict with algolia filter format
+            languages[i] = 'languages:"{}"'.format(languages[i].replace('"', "'"))
 
         # joining all possible language values to algolia filter query
         filters.append(f"( {' OR '.join(languages)} )")

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -664,6 +664,10 @@ def test_search_category_filter(module_client, module_db, fake_auth_from_oc, fak
     result = client.get("/api/v1/search?category=Books")
     assert (result.status_code == 200)
 
+    # Test with invalid category attribute given ( defaults to all )
+    result = client.get("/api/v1/search?category=")
+    assert (result.status_code == 200)
+
 
 def test_search_language_filter(module_client, module_db, fake_auth_from_oc, fake_algolia_save, fake_algolia_search):
     client = module_client
@@ -677,6 +681,13 @@ def test_search_language_filter(module_client, module_db, fake_auth_from_oc, fak
 
     # Test on multiple languages
     result = client.get("/api/v1/search?languages=python&languages=javascript")
+    assert (result.status_code == 200)
+
+    # Tests with invalid languages attribute given ( defaults to all )
+    result = client.get("/api/v1/search?languages=")
+    assert (result.status_code == 200)
+
+    result = client.get("/api/v1/search?languages=test&languages=")
     assert (result.status_code == 200)
 
 


### PR DESCRIPTION
Upon further testing (Thanks to chynh!), it appears `request.args.getlist` returns an empty list ( instead of `None` as I originally thought, my bad! ) which lead to `if ininstance(languages,list):` always being true which triggered an AlgoliaException due to filtering being invalid ( `filtering: ()` <- due to languages appending nothing)

Likewise for the `category` filtering; it appends an empty string (i.e: given `/search?category`) which leads to filtering error due to incorrect format

This should hopefully fix that issue.

See #234 for previous implementation and details
See [Filters](https://www.algolia.com/doc/api-reference/api-parameters/filters/) for how algolia filters