### PR TITLE
Add support for `languages[]` syntax

### DIFF
--- a/app/api/routes/resource_retrieval.py
+++ b/app/api/routes/resource_retrieval.py
@@ -38,6 +38,8 @@ def get_resources():
 
     # Fetch the filter params from the url, if they were provided.
     languages = request.args.getlist('languages')
+    if not languages:
+        languages = request.args.getlist('languages[]')
     category = request.args.get('category')
     updated_after = request.args.get('updated_after')
     paid = request.args.get('paid')

--- a/app/api/routes/search.py
+++ b/app/api/routes/search.py
@@ -23,6 +23,8 @@ def search_results():
     paid = request.args.get('paid')
     category = request.args.get('category')
     languages = request.args.getlist('languages')
+    if not languages:
+        languages = request.args.getlist('languages[]')
     filters = []
 
     # Filter on paid

--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -125,7 +125,7 @@ paths:
         - in: query
           name: languages
           required: false
-          description: Language(s) of the resource to search. For example, to filter for JavaScript and Python resources, make a `GET` request to `/search?languages=python&languages=javascript`.
+          description: "Language(s) of the resource to search. For example, to filter for JavaScript and Python resources, make a `GET` request to `/search?languages=python&languages=javascript`. Alternative syntax: `languages[]`"
           schema:
             type: array
         - in: query
@@ -621,7 +621,7 @@ paths:
         - in: query
           name: languages
           required: false
-          description: Language(s) of the resource. For example, to filter for Python and JavaScript resources, make a `GET` request to `/resources?languages=python&languages=javascript`
+          description: "Language(s) of the resource. For example, to filter for Python and JavaScript resources, make a `GET` request to `/resources?languages=python&languages=javascript`. Alternative syntax: `languages[]`"
           schema:
             type: string
         - in: query

--- a/tests/unit/test_routes/test_resource_retreival.py
+++ b/tests/unit/test_routes/test_resource_retreival.py
@@ -141,6 +141,16 @@ def test_language_filter(module_client, module_db):
             ('JavaScript' in resource.get('languages'))
         )
 
+    # Filter multiple with languages[] syntax
+    response = client.get('api/v1/resources?languages[]=python&languages[]=javascript')
+
+    for resource in response.json['data']:
+        assert (isinstance(resource.get('languages'), list))
+        assert (
+            ('Python' in resource.get('languages')) or
+            ('JavaScript' in resource.get('languages'))
+        )
+
     # Gibberish language returns a 404
     response = client.get('api/v1/resources?languages=gibberish', follow_redirects=True)
     assert_correct_response(response, 404)

--- a/tests/unit/test_routes/test_searching.py
+++ b/tests/unit/test_routes/test_searching.py
@@ -99,11 +99,17 @@ def test_search_language_filter(module_client,
     result = client.get("/api/v1/search?languages=python&languages=javascript")
     assert (result.status_code == 200)
 
+    result = client.get("/api/v1/search?languages[]=python&languages[]=javascript")
+    assert (result.status_code == 200)
+
     # Tests with invalid languages attribute given ( defaults to all )
     result = client.get("/api/v1/search?languages=")
     assert (result.status_code == 200)
 
     result = client.get("/api/v1/search?languages=test&languages=")
+    assert (result.status_code == 200)
+
+    result = client.get("/api/v1/search?languages[]=test&languages[]=")
     assert (result.status_code == 200)
 
 


### PR DESCRIPTION
The front end at operationcode.org/resources uses a library which translates an array called `languages` into a query string that looks like `languages[]=somelanguage&languages[]=someotherlanguage`. This adds support for this syntax with the `[]` on the end of the query parameter name of `languages[]`.

In the docs, I did not add a separate query parameter for this, I just mentioned in the description that `languages[]` will work as well.