### PR TITLE
Specify the datatype instead of just calling everything "data"

### DIFF
--- a/app/api/routes/api_key.py
+++ b/app/api/routes/api_key.py
@@ -43,7 +43,9 @@ def apikey():
                 return utils.standardize_response(status_code=500)
 
         logger.info(apikey.serialize)
-        return utils.standardize_response(payload=dict(data=apikey.serialize))
+        return utils.standardize_response(
+            payload=dict(data=apikey.serialize),
+            datatype="credentials")
     except Exception as e:
         logger.exception(e)
         return utils.standardize_response(status_code=500)
@@ -57,4 +59,6 @@ def rotate_apikey():
     new_key = rotate_key(g.auth_key, db.session)
     if not new_key:
         return utils.standardize_response(status_code=500)
-    return utils.standardize_response(payload=dict(data=new_key.serialize))
+    return utils.standardize_response(
+        payload=dict(data=new_key.serialize),
+        datatype="credentials")

--- a/app/api/routes/categories.py
+++ b/app/api/routes/categories.py
@@ -39,13 +39,16 @@ def get_categories():
 
     return utils.standardize_response(payload=dict(
         data=category_list,
-        **pagination_details))
+        **pagination_details),
+        datatype="categories")
 
 
 def get_category(id):
     category = Category.query.get(id)
 
     if category:
-        return utils.standardize_response(payload=dict(data=(category.serialize)))
+        return utils.standardize_response(
+            payload=dict(data=(category.serialize)),
+            datatype="category")
 
     return redirect('/404')

--- a/app/api/routes/languages.py
+++ b/app/api/routes/languages.py
@@ -39,13 +39,16 @@ def get_languages():
 
     return utils.standardize_response(payload=dict(
         data=language_list,
-        **pagination_details))
+        **pagination_details),
+        datatype="languages")
 
 
 def get_language(id):
     language = Language.query.get(id)
 
     if language:
-        return utils.standardize_response(payload=dict(data=(language.serialize)))
+        return utils.standardize_response(
+            payload=dict(data=(language.serialize)),
+            datatype="language")
 
     return redirect('/404')

--- a/app/api/routes/resource_creation.py
+++ b/app/api/routes/resource_creation.py
@@ -89,7 +89,9 @@ def create_resources(json, db):
                 return utils.standardize_response(payload=error, status_code=500)
 
         # Success
-        return utils.standardize_response(payload=dict(data=created_resources))
+        return utils.standardize_response(
+            payload=dict(data=created_resources),
+            datatype="resources")
     except Exception as e:
         logger.exception(e)
         return utils.standardize_response(status_code=500)

--- a/app/api/routes/resource_modification.py
+++ b/app/api/routes/resource_modification.py
@@ -78,7 +78,8 @@ def update_resource(id, json, db):
         db.session.commit()
 
         return utils.standardize_response(
-            payload=dict(data=resource.serialize)
+            payload=dict(data=resource.serialize),
+            datatype="resource"
         )
 
     except IntegrityError as e:
@@ -142,7 +143,9 @@ def update_votes(id, vote_direction):
             setattr(vote_info, 'current_direction', vote_direction)
     db.session.commit()
 
-    return utils.standardize_response(payload=dict(data=resource.serialize))
+    return utils.standardize_response(
+        payload=dict(data=resource.serialize),
+        datatype="resource")
 
 
 def add_click(id):
@@ -155,4 +158,6 @@ def add_click(id):
     setattr(resource, 'times_clicked', initial_count + 1)
     db.session.commit()
 
-    return utils.standardize_response(payload=dict(data=resource.serialize))
+    return utils.standardize_response(
+        payload=dict(data=resource.serialize),
+        datatype="resource")

--- a/app/api/routes/resource_retrieval.py
+++ b/app/api/routes/resource_retrieval.py
@@ -100,13 +100,16 @@ def get_resources():
 
     return utils.standardize_response(payload=dict(
         data=resource_list,
-        **pagination_details))
+        **pagination_details),
+        datatype="resources")
 
 
 def get_resource(id):
     resource = Resource.query.get(id)
 
     if resource:
-        return utils.standardize_response(payload=dict(data=(resource.serialize)))
+        return utils.standardize_response(
+            payload=dict(data=(resource.serialize)),
+            datatype="resource")
 
     return redirect('/404')

--- a/app/api/routes/search.py
+++ b/app/api/routes/search.py
@@ -79,4 +79,6 @@ def search_results():
             "total_count": search_result['nbHits'],
         }
     }
-    return utils.standardize_response(payload=dict(data=results, **pagination_details))
+    return utils.standardize_response(
+        payload=dict(data=results, **pagination_details),
+        datatype="resources")

--- a/app/static/openapi.yaml
+++ b/app/static/openapi.yaml
@@ -58,7 +58,7 @@ paths:
                 $ref: '#/components/schemas/ApiKeyResponse'
               example:
                 apiVersion: '1.0'
-                data:
+                credentials:
                   apikey: '1234567890'
                   email: 'your@email.com'
                 status: 'ok'
@@ -73,7 +73,6 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 apiVersion: '1.0'
-                data: null
                 errors:
                   unauthorized:
                     message: 'The email or password you submitted is incorrect'
@@ -95,7 +94,7 @@ paths:
                 $ref: '#/components/schemas/ApiKeyResponse'
               example:
                 apiVersion: '1.0'
-                data:
+                credentials:
                   apikey: '1234567890'
                   email: 'your@email.com'
                 status: 'ok'
@@ -119,7 +118,7 @@ paths:
         - in: query
           name: paid
           required: false
-          description: Whether the data is paid or not. To search for *free* resources, make a `GET` request to `/search?paid=false`.
+          description: Whether the resource is paid or not. To search for *free* resources, make a `GET` request to `/search?paid=false`.
           schema:
             type: boolean
         - in: query
@@ -143,7 +142,7 @@ paths:
                 $ref: '#/components/schemas/SearchResponse'
               example:
                 apiVersion: '1.0'
-                data:
+                resources:
                   - category': 'Tutorials'
                     created_at: '2019-05-25 18:52:15'
                     downvotes: 0
@@ -180,7 +179,7 @@ paths:
                 $ref: '#/components/schemas/Category'
               example:
                   apiVersion: '1.0'
-                  data:
+                  categories:
                     - id: 1
                       name: 'Books'
                     - id: 2
@@ -256,7 +255,7 @@ paths:
                 $ref: '#/components/schemas/Category_data'
               example:
                 apiVersion: '1.0'
-                data:
+                category:
                   id: 1
                   name: 'Books'
                 status: 'ok'
@@ -278,7 +277,7 @@ paths:
                 $ref: '#/components/schemas/Language'
               example:
                 apiVersion: '1.0'
-                data:
+                languages:
                   - id: 1
                     name: 'multiple'
                   - id: 2
@@ -354,7 +353,7 @@ paths:
                 $ref: '#/components/schemas/Language_data'
               example:
                 apiVersion: '1.0'
-                data:
+                language:
                   id: 2
                   name: 'Python'
                 status: 'ok'
@@ -386,19 +385,19 @@ paths:
                 $ref: '#/components/schemas/Resource'
               example:
                 apiVersion: '1.0'
-                data:
-                  - category: 'Books'
-                    created_at: '2019-06-15 17:55:32'
-                    downvotes: 0
-                    id: 3
-                    languages: []
-                    last_updated: '2019-06-15 17:55:32'
-                    name: 'Free Tech Books'
-                    notes: 'Focuses on general computer science concepts rather than a specific language'
-                    paid: false
-                    times_clicked: 0
-                    upvotes: 0
-                    url: 'http://www.freetechbooks.com/'
+                resource:
+                  category: 'Books'
+                  created_at: '2019-06-15 17:55:32'
+                  downvotes: 0
+                  id: 3
+                  languages: []
+                  last_updated: '2019-06-15 17:55:32'
+                  name: 'Free Tech Books'
+                  notes: 'Focuses on general computer science concepts rather than a specific language'
+                  paid: false
+                  times_clicked: 0
+                  upvotes: 0
+                  url: 'http://www.freetechbooks.com/'
                 status: 'ok'
                 status_code: 200
         404:
@@ -435,19 +434,19 @@ paths:
                 $ref: '#/components/schemas/Resource'
               example:
                 apiVersion: '1.0'
-                data:
-                  - category: 'Tutorial'
-                    created_at: '2019-07-21 15:41:19'
-                    downvotes: 0
-                    id: 2137
-                    languages: []
-                    last_updated: '2019-07-22 16:05:53'
-                    name: 'Updated Book Title'
-                    notes: null
-                    paid: false
-                    times_clicked: 3
-                    upvotes: 1
-                    url: 'http://www.test.com'
+                resource:
+                  category: 'Tutorial'
+                  created_at: '2019-07-21 15:41:19'
+                  downvotes: 0
+                  id: 2137
+                  languages: []
+                  last_updated: '2019-07-22 16:05:53'
+                  name: 'Updated Book Title'
+                  notes: null
+                  paid: false
+                  times_clicked: 3
+                  upvotes: 1
+                  url: 'http://www.test.com'
                 status: 'ok'
                 status_code: 200
         404:
@@ -462,7 +461,6 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 apiVersion: '1.0'
-                data: null
                 errors:
                   invalid-params:
                       message: 'The following params were invalid: url. Resource id 2137 already has this URL.'
@@ -499,19 +497,19 @@ paths:
                 $ref: '#/components/schemas/Resource_data'
               example:
                 apiVersion: '1.0'
-                data:
-                    - category: 'Books'
-                      created_at: '2019-04-28 22:18:34'
-                      downvotes: 0
-                      id: 10
-                      languages: []
-                      last_updated: '2019-07-26 13:47:52'
-                      name: 'Thinking Forth'
-                      notes: null
-                      paid: false
-                      times_clicked: 2
-                      upvotes: 0
-                      url: 'http://thinking-forth.sourceforge.net/'
+                resource:
+                    category: 'Books'
+                    created_at: '2019-04-28 22:18:34'
+                    downvotes: 0
+                    id: 10
+                    languages: []
+                    last_updated: '2019-07-26 13:47:52'
+                    name: 'Thinking Forth'
+                    notes: null
+                    paid: false
+                    times_clicked: 2
+                    upvotes: 0
+                    url: 'http://thinking-forth.sourceforge.net/'
                 status: 'ok'
                 status_code: 200
         404:
@@ -543,19 +541,19 @@ paths:
                 $ref: '#/components/schemas/Resource_data'
               example:
                 apiVersion: '1.0'
-                data:
-                  - category: 'Books'
-                    created_at: '2020-01-07 22:06:45'
-                    downvotes: 0
-                    id: 5
-                    languages: []
-                    last_updated: '2020-03-12 23:17:52'
-                    name: 'Teach Your Kids to Code'
-                    notes: null
-                    paid: true
-                    times_clicked: 0
-                    upvotes: 1
-                    url: 'http://teachyourkidstocode.com/'
+                resource:
+                  category: 'Books'
+                  created_at: '2020-01-07 22:06:45'
+                  downvotes: 0
+                  id: 5
+                  languages: []
+                  last_updated: '2020-03-12 23:17:52'
+                  name: 'Teach Your Kids to Code'
+                  notes: null
+                  paid: true
+                  times_clicked: 0
+                  upvotes: 1
+                  url: 'http://teachyourkidstocode.com/'
                 status: 'ok'
                 status_code: 200
         404:
@@ -587,19 +585,19 @@ paths:
                 $ref: '#/components/schemas/Resource_data'
               example:
                 apiVersion: '1.0'
-                data:
-                  - category: 'Books'
-                    created_at: '2020-01-07 22:06:45'
-                    downvotes: 1
-                    id: 5
-                    languages: []
-                    last_updated: '2020-03-12 23:17:52'
-                    name: 'Teach Your Kids to Code'
-                    notes: null
-                    paid: true
-                    times_clicked: 0
-                    upvotes: 0
-                    url: 'http://teachyourkidstocode.com/'
+                resource:
+                  category: 'Books'
+                  created_at: '2020-01-07 22:06:45'
+                  downvotes: 1
+                  id: 5
+                  languages: []
+                  last_updated: '2020-03-12 23:17:52'
+                  name: 'Teach Your Kids to Code'
+                  notes: null
+                  paid: true
+                  times_clicked: 0
+                  upvotes: 0
+                  url: 'http://teachyourkidstocode.com/'
                 status: 'ok'
                 status_code: 200
         404:
@@ -647,7 +645,7 @@ paths:
                 $ref: '#/components/schemas/FilteredResourcesResponse'
               example:
                 apiVersion: '1.0'
-                data:
+                resources:
                   - category': 'Tutorial'
                     created_at: '2019-07-21 15:41:19'
                     downvotes: 0
@@ -679,7 +677,6 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 apiVersion: '1.0'
-                data: null
                 errors:
                   unprocessable-entity:
                     message: 'The value for "updated_after" is invalid'
@@ -704,14 +701,14 @@ paths:
         required: true
       responses:
         200:
-          description: Created resource
+          description: Created resources
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Resource_list'
               example:
                 apiVersion: '1.0'
-                data:
+                resources:
                   - category: 'Tutorial'
                     created_at: '2019-07-21 15:41:19'
                     downvotes: 0
@@ -739,7 +736,6 @@ paths:
                 $ref: '#/components/schemas/Error_list'
               example:
                   apiVersion: '1.0'
-                  data: null
                   errors:
                     - index: 0
                       invalid-params:
@@ -767,9 +763,6 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
-          type: object
-          description: A data object
         errors:
           $ref: '#/components/schemas/Error_data'
         status:
@@ -843,9 +836,6 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
-          type: object
-          description: A data object
         errors:
           $ref: '#/components/schemas/Error_list_data'
         status:
@@ -926,7 +916,7 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
+        resource:
           $ref: '#/components/schemas/Resource_data'
         status:
           type: string
@@ -940,7 +930,7 @@ components:
       properties:
         apiVersion:
           type: string
-        data:
+        category:
           $ref: '#/components/schemas/Category_data'
         has_next:
           type: boolean
@@ -984,7 +974,7 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
+        language:
           $ref: '#/components/schemas/Language_data'
         has_next:
           type: boolean
@@ -1127,7 +1117,7 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
+        resources:
           type: array
           items:
             $ref: '#/components/schemas/Resource_data'
@@ -1156,7 +1146,7 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
+        resources:
           type: array
           items:
             $ref: '#/components/schemas/Resource_data'
@@ -1203,7 +1193,7 @@ components:
         apiVersion:
           type: string
           description: API version
-        data:
+        credentials:
           $ref: '#/components/schemas/ApiKeyResponse_data'
         status:
           type: string
@@ -1241,7 +1231,6 @@ components:
             $ref: '#/components/schemas/Error'
           example:
             apiVersion: '1.0'
-            data: null
             errors:
               not-found:
                 message: 'The resource you requested does not exist.'
@@ -1257,8 +1246,6 @@ components:
           example: |
             {
               'apiVersion': '1.0',
-              'data': null,
-              'error': 1,
               'errors': {
                 'unauthorized': {
                   'message': 'The email or password you submitted is incorrect'
@@ -1276,7 +1263,6 @@ components:
             $ref: '#/components/schemas/Error'
           example:
             apiVersion: '1.0'
-            data: null
             errors:
               unauthorized:
                 message: 'You must provide a valid API token in the x-apikey header.'
@@ -1291,7 +1277,6 @@ components:
             $ref: '#/components/schemas/Error'
           example:
             apiVersion: '1.0'
-            data: null
             errors:
               bad-request:
                 message: "400 Bad Request: Failed to decode JSON object: Expecting ',' delimiter: line 3 column 2 (char 25)"

--- a/app/utils.py
+++ b/app/utils.py
@@ -81,7 +81,11 @@ def format_resource_search(hit):
 
 
 @versioned(throw_on_invalid=False)
-def standardize_response(payload={}, status_code=200, version=LATEST_API_VERSION):
+def standardize_response(
+        payload={},
+        status_code=200,
+        version=LATEST_API_VERSION,
+        datatype="data"):
     """Response helper
     This simplifies the response creation process by providing an internally
     defined mapping of status codes to messages for errors. It also knows when
@@ -101,8 +105,7 @@ def standardize_response(payload={}, status_code=200, version=LATEST_API_VERSION
     resp = dict(
         apiVersion=version,
         status="ok",
-        status_code=status_code,
-        data=None
+        status_code=status_code
     )
 
     if status_code >= 400 and err_map.get(status_code):
@@ -124,7 +127,7 @@ def standardize_response(payload={}, status_code=200, version=LATEST_API_VERSION
         resp["status_code"] = 500
         resp["status"] = err_map.get(500)
     else:
-        resp["data"] = data
+        resp[datatype] = data
 
         if pagination_details:
             resp.update(pagination_details)

--- a/tests/unit/test_routes/helpers.py
+++ b/tests/unit/test_routes/helpers.py
@@ -74,7 +74,7 @@ def get_api_key(client):
         password="supersecurepassword"
     ))
 
-    return response.json['data'].get('apikey')
+    return response.json['credentials'].get('apikey')
 
 
 def assert_correct_response(response, code):

--- a/tests/unit/test_routes/test_api_key.py
+++ b/tests/unit/test_routes/test_api_key.py
@@ -11,8 +11,8 @@ def test_get_api_key(module_client, module_db, fake_auth_from_oc):
     ))
 
     assert (response.status_code == 200)
-    assert (response.json['data'].get('email') == "test@example.org")
-    assert (isinstance(response.json['data'].get('apikey'), str))
+    assert (response.json['credentials'].get('email') == "test@example.org")
+    assert (isinstance(response.json['credentials'].get('apikey'), str))
 
 
 def test_rotate_api_key(module_client, module_db, fake_auth_from_oc):
@@ -22,9 +22,9 @@ def test_rotate_api_key(module_client, module_db, fake_auth_from_oc):
     response = client.post('api/v1/apikey/rotate', headers={'x-apikey': apikey})
 
     assert (response.status_code == 200)
-    assert (isinstance(response.json['data'].get('email'), str))
-    assert (isinstance(response.json['data'].get('apikey'), str))
-    assert (response.json['data'].get('apikey') != apikey)
+    assert (isinstance(response.json['credentials'].get('email'), str))
+    assert (isinstance(response.json['credentials'].get('apikey'), str))
+    assert (response.json['credentials'].get('apikey') != apikey)
 
 
 def test_apikey_commit_error(

--- a/tests/unit/test_routes/test_categories.py
+++ b/tests/unit/test_routes/test_categories.py
@@ -6,7 +6,7 @@ def test_categories(module_client, module_db):
 
     response = client.get('api/v1/categories')
 
-    for category in response.json['data']:
+    for category in response.json['categories']:
         assert (isinstance(category.get('id'), int))
         assert (isinstance(category.get('name'), str))
         assert (category.get('name'))
@@ -30,7 +30,7 @@ def test_get_single_category(module_client, module_db):
     # Status should be OK
     assert (response.status_code == 200)
 
-    category = response.json['data']
+    category = response.json['category']
     assert (isinstance(category.get('name'), str))
     assert (category.get('id') == 4)
 

--- a/tests/unit/test_routes/test_invalid_put_post.py
+++ b/tests/unit/test_routes/test_invalid_put_post.py
@@ -69,9 +69,9 @@ def test_validate_resource(module_client, module_db, fake_auth_from_oc):
                           )
 
     assert (response.status_code == 200)
-    assert (response.json['data'].get('name') == "12345")
-    assert (response.json['data'].get('category') == "56789")
-    assert (response.json['data'].get('paid') is False)
+    assert (response.json['resource'].get('name') == "12345")
+    assert (response.json['resource'].get('category') == "56789")
+    assert (response.json['resource'].get('paid') is False)
 
     # URL must be string
     response = client.put("/api/v1/resources/2",

--- a/tests/unit/test_routes/test_languages.py
+++ b/tests/unit/test_routes/test_languages.py
@@ -5,7 +5,7 @@ def test_languages(module_client, module_db):
     client = module_client
 
     response = client.get('api/v1/languages')
-    for language in response.json['data']:
+    for language in response.json['languages']:
         assert (isinstance(language.get('id'), int))
         assert (isinstance(language.get('name'), str))
         assert (language.get('name'))
@@ -28,7 +28,7 @@ def test_get_single_language(module_client, module_db):
     # Status should be OK
     assert (response.status_code == 200)
 
-    language = response.json['data']
+    language = response.json['language']
     assert (isinstance(language.get('name'), str))
     assert (language.get('name'))
 

--- a/tests/unit/test_routes/test_resource_create.py
+++ b/tests/unit/test_routes/test_resource_create.py
@@ -14,8 +14,8 @@ def test_create_resource(
     apikey = get_api_key(client)
     response = create_resource(client, apikey)
     assert (response.status_code == 200)
-    assert (isinstance(response.json['data'][0].get('id'), int))
-    assert (response.json['data'][0].get('name') == "Some Name")
+    assert (isinstance(response.json['resources'][0].get('id'), int))
+    assert (response.json['resources'][0].get('name') == "Some Name")
 
     # Empty resource object
     response = client.post('/api/v1/resources',
@@ -55,7 +55,7 @@ def test_create_resource(
                                paid,
                                notes)
     assert (response.status_code == 200)
-    assert response.json['data'][0].get('paid') is False
+    assert response.json['resources'][0].get('paid') is False
     name = "StringsForBoolsTrue"
     url = None
     category = None
@@ -71,7 +71,7 @@ def test_create_resource(
                                paid,
                                notes)
     assert (response.status_code == 200)
-    assert response.json['data'][0].get('paid') is True
+    assert response.json['resources'][0].get('paid') is True
 
     # Bad "paid" data
     paid = "PERHAPS"
@@ -166,7 +166,7 @@ def test_create_multiple_resources(
                            headers={'x-apikey': apikey})
 
     assert (response.status_code == 200)
-    response_data = response.get_json().get("data")
+    response_data = response.get_json().get("resources")
     assert (len(response_data) == 2)
     for res in response_data:
         assert (res.get("url") == url1 or res.get("url") == url2)
@@ -183,7 +183,7 @@ def test_create_multiple_resources(
                            json=data,
                            headers={'x-apikey': apikey})
     assert (response.status_code == 422)
-    assert (response.get_json().get("data") is None)
+    assert (response.get_json().get("resources") is None)
     errors = response.get_json().get("errors")
     assert (isinstance(errors, list))
     assert (errors[0].get("index") == 0)
@@ -206,7 +206,7 @@ def test_create_multiple_resources(
                            json=data,
                            headers={'x-apikey': apikey})
     assert (response.status_code == 422)
-    assert (response.get_json().get("data") is None)
+    assert (response.get_json().get("resources") is None)
     assert (response.get_json().get("errors")[0].get("index") == 1)
 
 

--- a/tests/unit/test_routes/test_resource_retreival.py
+++ b/tests/unit/test_routes/test_resource_retreival.py
@@ -12,7 +12,7 @@ def test_get_resources(module_client, module_db):
 
     assert (response.status_code == 200)
 
-    for resource in response.json['data']:
+    for resource in response.json['resources']:
         assert (isinstance(resource.get('name'), str))
         assert (resource.get('name'))
         assert (isinstance(resource.get('url'), str))
@@ -54,7 +54,7 @@ def test_get_single_resource(module_client, module_db):
 
     assert (response.status_code == 200)
 
-    resource = response.json['data']
+    resource = response.json['resource']
     assert (isinstance(resource.get('name'), str))
     assert (resource.get('name'))
     assert (isinstance(resource.get('url'), str))
@@ -88,13 +88,13 @@ def test_paid_filter(module_client, module_db):
 
     total_free_resources = response.json['total_count']
 
-    assert all([not res.get('paid') for res in response.json['data']])
+    assert all([not res.get('paid') for res in response.json['resources']])
 
     response = client.get('api/v1/resources?paid=true')
 
     total_paid_resources = response.json['total_count']
 
-    assert all([res.get('paid') for res in response.json['data']])
+    assert all([res.get('paid') for res in response.json['resources']])
 
     # Check that the number of resources appear correct
     assert (total_paid_resources > 0)
@@ -106,10 +106,10 @@ def test_paid_filter_uppercase_parameter(module_client, module_db):
     client = module_client
 
     response = client.get('api/v1/resources?paid=TRUE')
-    assert all([res.get('paid') for res in response.json['data']])
+    assert all([res.get('paid') for res in response.json['resources']])
 
     response = client.get('api/v1/resources?paid=FALSE')
-    assert all([not res.get('paid') for res in response.json['data']])
+    assert all([not res.get('paid') for res in response.json['resources']])
 
 
 def test_paid_filter_invalid_paid_parameter(module_client, module_db):
@@ -117,8 +117,8 @@ def test_paid_filter_invalid_paid_parameter(module_client, module_db):
 
     response = client.get('api/v1/resources?paid=na93ns8i1ns')
 
-    assert (True in [res.get('paid') for res in response.json['data']])
-    assert (False in [res.get('paid') for res in response.json['data']])
+    assert (True in [res.get('paid') for res in response.json['resources']])
+    assert (False in [res.get('paid') for res in response.json['resources']])
 
 
 def test_language_filter(module_client, module_db):
@@ -127,14 +127,14 @@ def test_language_filter(module_client, module_db):
     # Filter by one language
     response = client.get('api/v1/resources?languages=python')
 
-    for resource in response.json['data']:
+    for resource in response.json['resources']:
         assert (isinstance(resource.get('languages'), list))
         assert ('Python' in resource.get('languages'))
 
     # Filter by multiple languages
     response = client.get('api/v1/resources?languages=python&languages=javascript')
 
-    for resource in response.json['data']:
+    for resource in response.json['resources']:
         assert (isinstance(resource.get('languages'), list))
         assert (
             ('Python' in resource.get('languages')) or
@@ -152,7 +152,7 @@ def test_category_filter(module_client, module_db):
     # Filter by category
     response = client.get('api/v1/resources?category=Back%20End%20Dev')
 
-    for resource in response.json['data']:
+    for resource in response.json['resources']:
         assert (resource.get('category') == "Back End Dev")
 
     # Gibberish category returns a 404
@@ -175,8 +175,8 @@ def test_updated_after_filter(module_client,
     create_resource(client, apikey)
     update_resource(client, apikey)
     response = client.get(f"/api/v1/resources?updated_after={filter_time}")
-    assert len(response.json['data']) == 2
-    for resource in response.json['data']:
+    assert len(response.json['resources']) == 2
+    for resource in response.json['resources']:
         assert (
                 filter_time <= datetime.strptime(resource.get('created_at'),
                                                  '%Y-%m-%d %H:%M:%S')

--- a/tests/unit/test_routes/test_resource_update.py
+++ b/tests/unit/test_routes/test_resource_update.py
@@ -11,7 +11,7 @@ def test_update_votes(module_client, module_db, fake_auth_from_oc, fake_algolia_
     id = 1
     apikey = get_api_key(client)
 
-    data = client.get(f"api/v1/resources/{id}").json['data']
+    data = client.get(f"api/v1/resources/{id}").json['resource']
     response = client.put(
                         f"/api/v1/resources/{id}/{UPVOTE}",
                         follow_redirects=True,
@@ -20,7 +20,7 @@ def test_update_votes(module_client, module_db, fake_auth_from_oc, fake_algolia_
     initial_downvotes = data.get(f"{DOWNVOTE}s")
 
     assert (response.status_code == 200)
-    assert (response.json['data'].get(f"{UPVOTE}s") == initial_upvotes + 1)
+    assert (response.json['resource'].get(f"{UPVOTE}s") == initial_upvotes + 1)
 
     response = client.put(
                         f"/api/v1/resources/{id}/{DOWNVOTE}",
@@ -28,15 +28,15 @@ def test_update_votes(module_client, module_db, fake_auth_from_oc, fake_algolia_
                         headers={'x-apikey': apikey})
     # Simple limit vote per user test
     assert (response.status_code == 200)
-    assert (response.json['data'].get(f"{UPVOTE}s") == initial_upvotes)
-    assert (response.json['data'].get(f"{DOWNVOTE}s") == initial_downvotes + 1)
+    assert (response.json['resource'].get(f"{UPVOTE}s") == initial_upvotes)
+    assert (response.json['resource'].get(f"{DOWNVOTE}s") == initial_downvotes + 1)
 
     response = client.put(
                         f"/api/v1/resources/{id}/{DOWNVOTE}",
                         follow_redirects=True,
                         headers={'x-apikey': apikey})
     assert (response.status_code == 200)
-    assert (response.json['data'].get(f"{DOWNVOTE}s") == initial_downvotes)
+    assert (response.json['resource'].get(f"{DOWNVOTE}s") == initial_downvotes)
 
 
 def test_update_votes_invalid(
@@ -79,12 +79,12 @@ def test_add_click(module_client, module_db):
 
     # Check clicking on a valid resource
     id = 1
-    data = client.get(f"api/v1/resources/{id}").json['data']
+    data = client.get(f"api/v1/resources/{id}").json['resource']
     response = client.put(f"/api/v1/resources/{id}/click", follow_redirects=True)
     initial_click_count = data.get(f"times_clicked")
 
     assert (response.status_code == 200)
-    assert (response.json['data'].get(f"times_clicked") == initial_click_count + 1)
+    assert (response.json['resource'].get(f"times_clicked") == initial_click_count + 1)
 
     # Check clicking on an invalid resource
     id = 'pancakes'
@@ -135,12 +135,12 @@ def test_update_resource(
     # Happy Path
     response = update_resource(client, apikey)
     assert (response.status_code == 200)
-    assert (response.json['data'].get('name') == "New name")
+    assert (response.json['resource'].get('name') == "New name")
 
     # Paid parameter as "FALSE" instead of False
     response = update_resource(client, apikey, name="New name 2", paid="FALSE")
     assert (response.status_code == 200)
-    assert (response.json['data'].get('name') == "New name 2")
+    assert (response.json['resource'].get('name') == "New name 2")
 
     # Bogus Data
     name = False
@@ -175,7 +175,7 @@ def test_update_resource(
                                paid,
                                notes)
     assert (response.status_code == 200)
-    assert response.json['data'].get('paid') is False
+    assert response.json['resource'].get('paid') is False
     name = "StringsForBools"
     url = None
     category = None
@@ -191,7 +191,7 @@ def test_update_resource(
                                paid,
                                notes)
     assert (response.status_code == 200)
-    assert response.json['data'].get('paid') is True
+    assert response.json['resource'].get('paid') is True
 
     # Bad "paid" data
     paid = "PERHAPS"

--- a/tests/unit/test_routes/test_searching.py
+++ b/tests/unit/test_routes/test_searching.py
@@ -26,11 +26,12 @@ def test_search(
 
     assert (resource.status_code == 200)
     assert (result.status_code == 200)
-    assert (result.json['data'][0]['url'] == resource.json['data'][0].get('url'))
+    assert (
+        result.json['resources'][0]['url'] == resource.json['resources'][0].get('url'))
 
     # Update the resource and test that search results reflect changes
     updated_term = random_string()
-    resource_id = resource.json['data'][0].get('id')
+    resource_id = resource.json['resources'][0].get('id')
     resource = client.put(f"/api/v1/resources/{resource_id}",
                           json=dict(url=f"{updated_term}",),
                           headers={'x-apikey': apikey})
@@ -39,7 +40,7 @@ def test_search(
 
     assert (resource.status_code == 200)
     assert (result.status_code == 200)
-    assert (result.json['data'][0]['url'] == resource.json['data'].get('url'))
+    assert (result.json['resources'][0]['url'] == resource.json['resource'].get('url'))
 
 
 def test_search_paid_filter(module_client,

--- a/tests/unit/test_routes/test_utils.py
+++ b/tests/unit/test_routes/test_utils.py
@@ -30,32 +30,32 @@ def test_paginator(module_client, module_db):
 
     # Default page size
     response = client.get('api/v1/resources')
-    assert (len(response.json['data']) == PaginatorConfig.per_page)
+    assert (len(response.json['resources']) == PaginatorConfig.per_page)
 
     # Test page size
     response = client.get('api/v1/resources?page_size=1')
-    assert (len(response.json['data']) == 1)
+    assert (len(response.json['resources']) == 1)
     response = client.get('api/v1/resources?page_size=5')
-    assert (len(response.json['data']) == 5)
+    assert (len(response.json['resources']) == 5)
     response = client.get('api/v1/resources?page_size=10')
-    assert (len(response.json['data']) == 10)
+    assert (len(response.json['resources']) == 10)
     response = client.get('api/v1/resources?page_size=100')
-    assert (len(response.json['data']) == 100)
+    assert (len(response.json['resources']) == 100)
 
     # Test pages different and sequential
-    first_page_resource = response.json['data'][0]
+    first_page_resource = response.json['resources'][0]
     assert (first_page_resource.get('id') == 1)
     response = client.get('api/v1/resources?page_size=100&page=2')
-    second_page_resource = response.json['data'][0]
+    second_page_resource = response.json['resources'][0]
     assert (second_page_resource.get('id') == 101)
     response = client.get('api/v1/resources?page_size=100&page=3')
-    third_page_resource = response.json['data'][0]
+    third_page_resource = response.json['resources'][0]
     assert (third_page_resource.get('id') == 201)
 
     # Test bigger than max page size
     too_long = PaginatorConfig.max_page_size + 1
     response = client.get(f"api/v1/resources?page_size={too_long}")
-    assert (len(response.json['data']) == PaginatorConfig.max_page_size)
+    assert (len(response.json['resources']) == PaginatorConfig.max_page_size)
     assert (response.json['records_per_page'] == PaginatorConfig.max_page_size)
 
     # Test pagination details are included


### PR DESCRIPTION
Per @kylemh and @manthonyg, the front end code is [getting unwieldy](https://github.com/OperationCode/front-end/pull/1100#discussion_r422439722). This changes the `data` attribute to be called the actual description of the data.

This is a pretty big breaking change, but I'm choosing not to increment the API version because there are currently no production clients that are depending on the API in its current state. If there is anything up at https://operationcode.org/resources currently, it's almost certain that no one is actually using it, so if it breaks that's ok.

Changelist:
- Call the data returned from the "API Key Request" endpoint `credentials`
- Call the data returned from "Search", "List Resources", and "Create Resources" endpoints `resources`
- Call the data returned from the "Get Resource", and "Update Resources" endpoints `resource`
- Call the data returned from the "List Categories" endpoint `categories`
- Call the data returned from the "Get Category" endpoint `category`
- Call the data returned from the "List Languages" endpoint `languages`
- Call the data returned from the "Get Language" endpoint `language`
- Update the tests to pass given the breaking changes
- Update the documentation to reflect the changes