### PR TITLE
Add vercel.app to CORS allowed origins

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -6,7 +6,8 @@ bp = Blueprint('api', __name__)
 ALLOWED_ORIGINS = [
     'http://localhost:3000',
     r"https:\/\/(www\.)?operationcode\.org",
-    r"https:\/\/(.*\.)?operation-code(-.*)?\.now\.sh"
+    r"https:\/\/(.*\.)?operation-code(-.*)?\.now\.sh",
+    r"https:\/\/(.*\.)?operation-code(-.*)?\.vercel\.app"
 ]
 
 CORS(bp, origins=ALLOWED_ORIGINS)


### PR DESCRIPTION
Since Zeit has rebranded `now.sh` as `vercel.app`, we're seeing CORS issues on https://operation-code-git-update-deps.operation-code.vercel.app/resources/1

This should fix that issue.