### PR TITLE
Raise DBAPIError rather than None

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from algoliasearch.exceptions import (AlgoliaException,
 from app import app
 from app import db as _db
 from app.utils import standardize_response
+from sqlalchemy.exc import DBAPIError
 
 TEST_DATABASE_URI = 'sqlite:///:memory:'
 
@@ -190,7 +191,7 @@ def fake_category_query_error(mocker):
     Mocks an exception being raised during a query to test error handling
     """
 
-    mocker.patch('app.models.Category.query', new=None)
+    mocker.patch('app.models.Category.query', side_effect=DBAPIError)
 
 
 @pytest.fixture(scope='function')
@@ -199,7 +200,7 @@ def fake_language_query_error(mocker):
     Mocks an exception being raised during a query to test error handling
     """
 
-    mocker.patch('app.models.Language.query', new=None)
+    mocker.patch('app.models.Language.query', side_effect=DBAPIError)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
When we merged #341, the tests started failing on this line
https://github.com/OperationCode/resources_api/blob/b4d281c2d8215162309a2db3f66d20d13fe8716b/app/api/routes/resource_retrieval.py#L91

I'm not sure exactly why this fixes it, but it's more correct anyway and it happens to fix the tests. I'm going to merge it and then do some manual testing on staging and make sure everything is good to go before we deploy to prod.