### PR TITLE
Use CIRCLE_SHA1 as the image tag instead of BUILD_NUM which is unreliable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,11 @@ workflows:
           tag: latest
           after_build:
             - run:
-                name: Tag and Push with $CIRCLE_BUILD_NUM
+                name: Tag and Push with $CIRCLE_SHA1
                 command: |
                   IMAGE_ID=operationcode/resources-api
-                  docker tag ${IMAGE_ID}:latest ${IMAGE_ID}:${CIRCLE_BUILD_NUM}
-                  docker push ${IMAGE_ID}:${CIRCLE_BUILD_NUM}
+                  docker tag ${IMAGE_ID}:latest ${IMAGE_ID}:${CIRCLE_SHA1}
+                  docker push ${IMAGE_ID}:${CIRCLE_SHA1}
           requires:
             - build_test
           filters:
@@ -29,7 +29,7 @@ workflows:
 
       # Deploy the new docker image to the AWS EKS cluster, staging namespace
       - aws-eks/update-container-image:
-          container-image-updates: 'app=operationcode/resources-api:${CIRCLE_BUILD_NUM}'
+          container-image-updates: 'app=operationcode/resources-api:${CIRCLE_SHA1}'
           cluster-name: 'operationcode-backend'
           namespace: 'operationcode-staging'
           resource-name: 'deployment/resources-api'


### PR DESCRIPTION
The problem here: https://app.circleci.com/pipelines/github/OperationCode/resources_api/524/workflows/39d5b471-abef-4067-b6a1-50d021043875/jobs/648

was that using CIRCLE_BUILD_NUM is unreliable because each workflow job will have a new number.   This PR proposes using the git commit sha as the tag instead, which is more reliable and traceable back to git!

Signed-off-by: Irving Popovetsky <irving@popovetsky.com>