### PR TITLE
Wrapped resource.serialize with json.dumps() to convert object to json

### DIFF
--- a/app/api/routes/resource_modification.py
+++ b/app/api/routes/resource_modification.py
@@ -11,6 +11,7 @@ from app.api.routes.helpers import (
     failures_counter, get_attributes, latency_summary, logger, ensure_bool)
 from app.api.validations import requires_body, validate_resource, wrong_type
 from app.models import Resource, VoteInformation, Key
+import json as json_module
 
 
 @latency_summary.time()
@@ -42,7 +43,8 @@ def update_resource(id, json, db):
     index_object = {'objectID': id}
 
     try:
-        logger.info(f"Updating resource. Old data: {resource.serialize}")
+        logger.info(
+            f"Updating resource. Old data: {json_module.dumps(resource.serialize)}")
         if json.get('languages'):
             resource.languages = langs
             index_object['languages'] = resource.serialize['languages']


### PR DESCRIPTION
Fixes #356 

example PUT to api/v1/resources/1:
```json
{
    "notes": "test2"
}
```

old logs: 
```
2020-08-13 02:54:24,753 INFO User: ekmendes1@gmail.com Route: /api/v1/resources/1 Payload: {'notes': 'test2'}
2020-08-13 02:54:24,788 INFO Updating resource. Old data: {'id': 1, 'name': 'Free Programming Books', 'url': 'https://github.com/vhf/free-programming-books', 'category': 'Books', 'languages': ['multiple'], 'paid': False, 'notes': 'test1', 'upvotes': 0, 'downvotes': 0, 'times_clicked': 0, 'created_at': '2020-08-02 03:04:21', 'last_updated': '2020-08-13 02:49:18'}
```

new logs:
```
2020-08-13 02:49:18,768 INFO User: ekmendes1@gmail.com Route: /api/v1/resources/1 Payload: {'notes': 'test1'}
2020-08-13 02:49:18,816 INFO Updating resource. Old data: {"id": 1, "name": "Free Programming Books", "url": "https://github.com/vhf/free-programming-books", "category": "Books", "languages": ["multiple"], "paid": false, "notes": null, "upvotes": 0, "downvotes": 0, "times_clicked": 0, "created_at": "2020-08-02 03:04:21", "last_updated": ""}
```
