### PR TITLE
Support authorization header

### DIFF
--- a/app/api/routes/resource_modification.py
+++ b/app/api/routes/resource_modification.py
@@ -1,7 +1,7 @@
 from os import environ
 
 from algoliasearch.exceptions import AlgoliaException, AlgoliaUnreachableHostException
-from flask import redirect, request
+from flask import redirect, request, g
 from sqlalchemy.exc import IntegrityError
 
 from app import db, index, utils as utils
@@ -119,7 +119,7 @@ def update_votes(id, vote_direction):
     opposite_direction = 'downvotes' if vote_direction == 'upvotes' else 'upvotes'
     opposite_count = getattr(resource, opposite_direction)
 
-    api_key = request.headers.get('x-apikey')
+    api_key = g.auth_key.apikey
     vote_info = VoteInformation.query.get(
                 {'voter_apikey': api_key, 'resource_id': id}
             )

--- a/tests/unit/test_routes/test_resource_update.py
+++ b/tests/unit/test_routes/test_resource_update.py
@@ -5,6 +5,7 @@ from .helpers import (
 
 from ..test_auth_jwt import GOOD_AUTH
 
+
 def test_update_votes(module_client, module_db, fake_auth_from_oc, fake_algolia_save):
     client = module_client
     UPVOTE = 'upvote'


### PR DESCRIPTION
We discovered an auth error in OperationCode/front-end#1283 where the API doesn't know how to handle an upvote or downvote without an API key sent in the header. This should fix that issue.