### PR TITLE
Refactored CI to use a separate CI compose file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            make test
+            make COMPOSE_FILE="docker-compose.ci.yml" test-coverage-ci
       - run:
           name: Run linting and coverage
           command: |
-            make lint
-            docker-compose run resources-api coverage xml
+            make COMPOSE_FILE="docker-compose.ci.yml" lint
             /usr/local/bin/cc-test-reporter after-build
       - run:
           name: Run Bandit security analysis
           command: |
-            make bandit
+            make COMPOSE_FILE="docker-compose.ci.yml" bandit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCKER := docker
 DOCKER_COMPOSE := docker-compose
+COMPOSE_FILE := docker-compose.yml
 RESOURCES_CONTAINER := resources-api
 RESOURCES_DB := resources-postgres
 FLASK := flask
@@ -15,7 +16,7 @@ endif
 
 .PHONY:  shell
 shell:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} shell
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} shell
 	
 .PHONY:  nuke
 nuke:
@@ -23,11 +24,11 @@ nuke:
 
 .PHONY: minty-fresh
 minty-fresh:
-	${DOCKER_COMPOSE} down --rmi all --volumes --remove-orphans
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} down --rmi all --volumes --remove-orphans
 
 add remove:
 	@if [ -z $(shell echo ${ARGS} | cut -d' ' -f1) ]; then echo "Please provide a proper package name"; exit 1; fi
-	if [ ! "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} up --build -d; fi
+	if [ ! "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} -f ${COMPOSE_FILE} up --build -d; fi
 	${DOCKER} exec ${RESOURCES_CONTAINER} /bin/bash -c "poetry $@ $(shell echo ${ARGS} | cut -d' ' -f1)"
 %:
 	@:
@@ -49,72 +50,77 @@ fresh-restart: minty-fresh test setup run
 
 .PHONY: run-with-metrics
 run-with-metrics: build
-	if [ "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} down; fi
-	${DOCKER_COMPOSE} run -p 5000:5000 ${RESOURCES_CONTAINER}
+	if [ "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} -f ${COMPOSE_FILE} down; fi
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run -p 5000:5000 ${RESOURCES_CONTAINER}
 
 .PHONY: run
 run: build
-	if [ "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} down; fi
-	${DOCKER_COMPOSE} run -p 5000:5000 ${RESOURCES_CONTAINER} ${FLASK} run -h 0.0.0.0
+	if [ "$$(${DOCKER} ps -q -f name=resources-api)" ]; then ${DOCKER_COMPOSE} -f ${COMPOSE_FILE} down; fi
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run -p 5000:5000 ${RESOURCES_CONTAINER} ${FLASK} run -h 0.0.0.0
 
 run_windows: build
-	@cmd /c (IF NOT "$(shell ${DOCKER} ps -q -f name=resources-api)" == "" ${DOCKER_COMPOSE} down)
-	${DOCKER_COMPOSE} run -p 5000:5000 ${RESOURCES_CONTAINER} ${FLASK} run -h 0.0.0.0
+	@cmd /c (IF NOT "$(shell ${DOCKER} ps -q -f name=resources-api)" == "" ${DOCKER_COMPOSE} -f ${COMPOSE_FILE} down)
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run -p 5000:5000 ${RESOURCES_CONTAINER} ${FLASK} run -h 0.0.0.0
 
 
 .PHONY: bg
 bg:
-	${DOCKER_COMPOSE} up --build -d
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} up --build -d
 
 .PHONY: routes
 routes:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} routes
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} routes
 
 .PHONY: test
 test: build
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} py.test --cov=app/ tests/
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} py.test --cov=app/ tests/
 
 .PHONY: test-coverage
 test-coverage:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} py.test --cov-report html --cov=app/ tests/
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} py.test --cov-report html --cov=app/ tests/
+
+.PHONY: test-coverage-ci
+test-coverage-ci:
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run --name coverage_test_run ${RESOURCES_CONTAINER} py.test --cov-report xml --cov=app/ tests/
+	docker cp coverage_test_run:/src/coverage.xml coverage.xml
 
 # Usage: make test-single tests/unit/test_api_key.py::test_get_api_key
 .PHONY: test-single
 test-single: build
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} /bin/bash -c "py.test --cov=app/ $(shell echo ${ARGS})"
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} /bin/bash -c "py.test --cov=app/ $(shell echo ${ARGS})"
 
 .PHONY: lint
 lint:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} flake8 . --exclude migrations --statistics --count
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} flake8 . --exclude migrations --statistics --count
 
 .PHONY: bandit
 bandit:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} bandit -r .
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} bandit -r .
 
 .PHONY: help
 help: build
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} --help
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} --help
 
 .PHONY: build
 build:
-	${DOCKER_COMPOSE} build --pull ${RESOURCES_CONTAINER}
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} build --pull ${RESOURCES_CONTAINER}
 
 .PHONY: setup
 setup: bg
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK}
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} db-migrate create-tables
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} db stamp head
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} db-migrate init
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK}
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} db-migrate create-tables
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} db stamp head
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} db-migrate init
 
 .PHONY: migrate
 migrate: build
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} db migrate
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} db upgrade
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} db migrate
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} db upgrade
 
 .PHONY: reindex
 reindex:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} algolia reindex
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} algolia reindex
 
 .PHONY: bad-urls
 bad-urls:
-	${DOCKER_COMPOSE} run ${RESOURCES_CONTAINER} ${FLASK} check-bad-urls
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run ${RESOURCES_CONTAINER} ${FLASK} check-bad-urls

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ test-coverage:
 
 .PHONY: test-coverage-ci
 test-coverage-ci:
-	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run --name coverage_test_run ${RESOURCES_CONTAINER} py.test --cov-report xml --cov=app/ tests/
+	${DOCKER_COMPOSE} -f ${COMPOSE_FILE} run --name coverage_test_run ${RESOURCES_CONTAINER} \
+	/bin/bash -c "py.test --cov=app/ tests/ && coverage xml"
 	docker cp coverage_test_run:/src/coverage.xml coverage.xml
 
 # Usage: make test-single tests/unit/test_api_key.py::test_get_api_key

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,30 @@
+version: "3.6"
+services:
+  resources-api:
+    image: resources:latest
+    build: .
+    container_name: resources-api
+    env_file:
+      - .env
+    ports:
+      - 5000:5000
+    links:
+      - resources-postgres
+    depends_on:
+      - resources-postgres
+
+  resources-postgres:
+    image: postgres:10.1-alpine
+    container_name: resources-postgres
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_HOST=${POSTGRES_HOST}
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: resources:latest
     build: .
     container_name: resources-api
+    user: root
     env_file:
     - .env
     volumes:


### PR DESCRIPTION
Helloo!
[issue-334](https://github.com/OperationCode/resources_api/issues/399)

This should help fix the issue with the user permissions that was discussed [previously](https://github.com/OperationCode/resources_api/issues/399#issuecomment-713233695), instead of making a separate command for each command used in the CI since I felt like it wouldn't be a very clean way, I added a `COMPOSE_FILE` variable that can be easily changed and will allow us to easily change the compose file for any commands that we would want to add in the future for both.  Let me know if you think if this won't be necessary, either way its a small change