### PR TITLE
chore(#82): Consistent Error Presentation

### DIFF
--- a/app/api/routes/helpers.py
+++ b/app/api/routes/helpers.py
@@ -11,7 +11,7 @@ failures_counter = Counter('my_failures', 'Number of exceptions raised')
 def unauthorized_response():
     message = "The email or password you submitted is incorrect " \
               "or your account is not allowed api access"
-    payload = {'errors': {"unauthorized": {"message": message}}}
+    payload = {'errors': [{"unauthorized": {"message": message}}]}
     return utils.standardize_response(payload=payload, status_code=401)
 
 

--- a/app/api/routes/resource_retrieval.py
+++ b/app/api/routes/resource_retrieval.py
@@ -74,7 +74,7 @@ def get_resources():
         except Exception as e:
             logger.exception(e)
             message = 'The value for "updated_after" is invalid'
-            res = {"errors": {"unprocessable-entity": {"message": message}}}
+            res = {"errors": [{"unprocessable-entity": {"message": message}}]}
             return utils.standardize_response(payload=res, status_code=422)
 
         q = q.filter(

--- a/app/api/validations.py
+++ b/app/api/validations.py
@@ -11,15 +11,11 @@ INVALID_TYPE = "invalid-type"
 
 def requires_body(func):
     def wrapper(*args, **kwargs):
-        try:
-            # JSON body is {} or []
-            if not request.get_json():
-                return missing_json_error()
-        except Exception as e:
-            # JSON body is completely missing
-            if "Expecting value: line 1 column 1" in str(e):
-                return missing_json_error()
-
+        # JSON body is {} or []
+        # This will throw a 400 if the JSON is malformed
+        # and drop into handlers.bad_request()
+        if not request.get_json():
+            return missing_json_error()
         return func(*args, **kwargs)
     return wrapper
 

--- a/app/api/validations.py
+++ b/app/api/validations.py
@@ -1,5 +1,4 @@
 from flask import request
-from werkzeug.exceptions import BadRequest
 from app.models import Resource
 from app.utils import standardize_response
 

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -6,7 +6,7 @@ from app.utils import standardize_response
 # Error Handlers
 @bp.app_errorhandler(400)
 def bad_request(e):
-    errors = {"errors": {"bad-request": {"message": str(e)}}}
+    errors = {"errors": [{"bad-request": {"message": str(e)}}]}
     return standardize_response(payload=errors, status_code=400)
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -116,13 +116,13 @@ def standardize_response(
         else:
             code = get_error_code_from_status(status_code)
             message = msg_map.get(status_code)
-            resp["errors"] = {}
-            resp["errors"][code] = {"message": message}
+            resp["errors"] = []
+            resp["errors"].append({code: {"message": message}})
 
     elif not data:
         # 500 Error case -- Something went wrong.
         message = msg_map.get(500)
-        resp["errors"] = {"server-error": {"message": message}}
+        resp["errors"] = [{"server-error": {"message": message}}]
         resp["status_code"] = 500
         resp["status"] = err_map.get(500)
     else:

--- a/tests/unit/test_routes/helpers.py
+++ b/tests/unit/test_routes/helpers.py
@@ -79,23 +79,29 @@ def get_api_key(client):
 
 def assert_correct_response(response, code):
     assert (response.status_code == code)
-    assert (isinstance(response.json.get('errors').get(
-        get_error_code_from_status(response.status_code)), dict))
-    assert (isinstance(response.json.get('errors').get(
-        get_error_code_from_status(response.status_code)).get('message'), str))
+    assert (isinstance(
+                response.json.get('errors')[0].get(
+                    get_error_code_from_status(response.status_code)
+                ),
+                dict))
+    assert (isinstance(
+                response.json.get('errors')[0].get(
+                    get_error_code_from_status(response.status_code)
+                ).get('message'),
+                str))
 
 
 def assert_correct_validation_error(response, params):
     assert (response.status_code == 422)
-    assert (isinstance(response.json.get('errors')
+    assert (isinstance(response.json.get('errors')[0]
             .get(INVALID_PARAMS), dict))
-    assert (isinstance(response.json.get('errors')
+    assert (isinstance(response.json.get('errors')[0]
             .get(INVALID_PARAMS).get('message'), str))
 
     for param in params:
-        assert (param in response.json.get('errors')
+        assert (param in response.json.get('errors')[0]
                 .get(INVALID_PARAMS).get("params"))
-        assert (param in response.json.get('errors')
+        assert (param in response.json.get('errors')[0]
                 .get(INVALID_PARAMS).get("message"))
 
 
@@ -146,4 +152,4 @@ def assert_missing_params_create(response, params, index):
 def assert_wrong_type(response, expected_type):
     assert (response.status_code == 422)
     assert (expected_type in response.get_json()
-            .get("errors").get(INVALID_TYPE).get("message"))
+            .get("errors")[0].get(INVALID_TYPE).get("message"))

--- a/tests/unit/test_routes/helpers.py
+++ b/tests/unit/test_routes/helpers.py
@@ -153,3 +153,11 @@ def assert_wrong_type(response, expected_type):
     assert (response.status_code == 422)
     assert (expected_type in response.get_json()
             .get("errors")[0].get(INVALID_TYPE).get("message"))
+
+
+def assert_bad_request(response):
+    assert (response.status_code == 400)
+    assert (isinstance(response.json.get('errors')[0]
+                       .get('bad-request'), dict))
+    assert (isinstance(response.json.get('errors')[0]
+                       .get('bad-request').get('message'), str))

--- a/tests/unit/test_routes/test_invalid_put_post.py
+++ b/tests/unit/test_routes/test_invalid_put_post.py
@@ -1,6 +1,6 @@
 from .helpers import (
     create_resource, get_api_key, assert_correct_response,
-    assert_correct_validation_error, assert_missing_body
+    assert_correct_validation_error, assert_missing_body, assert_bad_request
 )
 
 
@@ -97,15 +97,15 @@ def test_validate_resource(module_client, module_db, fake_auth_from_oc):
                           )
     assert_missing_body(response)
 
-    # Data cannot be empty
+    # Data must be valid json
     response = client.put(
         "api/v1/resources/1",
-        data='',
+        data='this is not json',
         content_type='application/json',
         headers={'x-apikey': apikey},
         follow_redirects=True
     )
-    assert_missing_body(response)
+    assert_bad_request(response)
 
 
 def test_create_with_invalid_apikey(module_client, module_db):


### PR DESCRIPTION
# Intro
👋 This is my first PR to this project! It's highly likely I have misunderstood something along the way. Happy to revisit and rework any of this!

# What is this?

I started looking at some of the complexity issues raised by Code Climate for #82, specifically that of `app.api.validations.requires_body`.

I realised that the cognitive complexity can be reduced by removing the explicit error handling in this function and letting flask raise the appropriate error (see [Request.get_json](https://tedboy.github.io/flask/generated/generated/flask.Request.get_json.html)) if the JSON is malformed (and there is already an error handler for this). I think this code only needs to handle the error case which is specific to the app (ie. we must have content in the payload).

However, this uncovered inconsistencies in the formatting of API responses when it comes to errors. It caused a lot of test failures and a lot of head scratching on my part.

It looks as though the codebase already attempts to standardise responses, but as the errors payload is sometimes passed in, it has the potential to be inconsistent. Sometimes it is an array of dicts, sometimes just a single dict.

Long term, I think the creation of error responses could be standardised further but for now I updated each of the manual entries so that errors are always presented as arrays of dicts, like this:

```
{
    "errors": [
        {
            "message": ""
        }
    ]
```

# Testing
Updated existing tests in line with changes.

# Question
Might these changes to error responses have any effect on the front end?